### PR TITLE
Merge latest PowerToys main with Windows App SDK 1.6

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -266,6 +266,7 @@ CSettings
 cso
 CSRW
 CStyle
+cswinrt
 CSY
 CTest
 currentculture

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -241,6 +241,17 @@ configuration:
       then:
       - addReply:
           reply: Hi! Your last comment indicates to our system, that you might want to contribute to this feature/fix this bug. Thank you! Please make us aware on our ["Would you like to contribute to PowerToys?" thread](https://github.com/microsoft/PowerToys/issues/28769), as we don't see all the comments. <br /><br />_I'm a bot (beep!) so please excuse any mistakes I may make_
+      description:
+    - if:
+      - payloadType: Issues
+      - isAction:
+          action: Opened
+      - bodyContains:
+          pattern: 'Area\(s\) with issue\?\s*\nWorkspaces'
+          isRegex: True
+      then:
+      - addLabel:
+          label: Product-Workspaces
       description: 
 onFailure: 
 onSuccess: 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,15 +35,19 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2365.46" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2739.15" />
     <!-- Package Microsoft.Win32.SystemEvents added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.1. This is a dependency of System.Drawing.Common but the 8.0.1 version wasn't published to nuget. -->
     <PackageVersion Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Windows.Compatibility" Version="8.0.7" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.46-beta" />
     <!-- CsWinRT version needs to be set to have a WinRT.Runtime.dll at the same version contained inside the NET SDK we're currently building on CI. -->
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.0.8" />
+    <!-- 
+      TODO: in Common.Dotnet.CsWinRT.props, on upgrade, verify RemoveCsWinRTPackageAnalyzer is no longer needed.  
+      This is present due to a bug in CsWinRT where WPF projects cause the analyzer to fail.
+	-->
+    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.5.240428000" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageVersion Include="ModernWpfUI" Version="0.9.4" />

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1325,13 +1325,13 @@ EXHIBIT A -Mozilla Public License.
 - Microsoft.Extensions.Logging 8.0.0
 - Microsoft.Extensions.Logging.Abstractions 8.0.0
 - Microsoft.Toolkit.Uwp.Notifications 7.1.2
-- Microsoft.Web.WebView2 1.0.2365.46
+- Microsoft.Web.WebView2 1.0.2739.15
 - Microsoft.Win32.SystemEvents 8.0.0
 - Microsoft.Windows.Compatibility 8.0.7
 - Microsoft.Windows.CsWin32 0.2.46-beta
-- Microsoft.Windows.CsWinRT 2.0.8
+- Microsoft.Windows.CsWinRT 2.1.1
 - Microsoft.Windows.SDK.BuildTools 10.0.22621.2428
-- Microsoft.WindowsAppSDK 1.5.240428000
+- Microsoft.WindowsAppSDK 1.6.240829007
 - Microsoft.Xaml.Behaviors.WinUI.Managed 2.0.9
 - Microsoft.Xaml.Behaviors.Wpf 1.1.39
 - ModernWpfUI 0.9.4

--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ Go to the [Microsoft PowerToys GitHub releases page][github-release-link] and cl
 <!-- items that need to be updated release to release -->
 [github-next-release-work]: https://github.com/microsoft/PowerToys/issues?q=is%3Aissue+milestone%3A%22PowerToys+0.85%22
 [github-current-release-work]: https://github.com/microsoft/PowerToys/issues?q=is%3Aissue+milestone%3A%22PowerToys+0.84%22
-[ptUserX64]: https://github.com/microsoft/PowerToys/releases/download/v0.84.0/PowerToysUserSetup-0.84.0-x64.exe
-[ptUserArm64]: https://github.com/microsoft/PowerToys/releases/download/v0.84.0/PowerToysUserSetup-0.84.0-arm64.exe
-[ptMachineX64]: https://github.com/microsoft/PowerToys/releases/download/v0.84.0/PowerToysSetup-0.84.0-x64.exe
-[ptMachineArm64]: https://github.com/microsoft/PowerToys/releases/download/v0.84.0/PowerToysSetup-0.84.0-arm64.exe
+[ptUserX64]: https://github.com/microsoft/PowerToys/releases/download/v0.84.1/PowerToysUserSetup-0.84.1-x64.exe
+[ptUserArm64]: https://github.com/microsoft/PowerToys/releases/download/v0.84.1/PowerToysUserSetup-0.84.1-arm64.exe
+[ptMachineX64]: https://github.com/microsoft/PowerToys/releases/download/v0.84.1/PowerToysSetup-0.84.1-x64.exe
+[ptMachineArm64]: https://github.com/microsoft/PowerToys/releases/download/v0.84.1/PowerToysSetup-0.84.1-arm64.exe
  
 |  Description   | Filename | sha256 hash |
 |----------------|----------|-------------|
-| Per user - x64       | [PowerToysUserSetup-0.84.0-x64.exe][ptUserX64] | 6792180D697ED9FDF9AA7B3F0AB92767CF4C79B526715C802F545E2DCB201BE3 |
-| Per user - ARM64     | [PowerToysUserSetup-0.84.0-arm64.exe][ptUserArm64] | 3D071F009B5E3DBAD21D7450ADB53CBC85CAFB21016E44F414E2A03C188D2FAF |
-| Machine wide - x64   | [PowerToysSetup-0.84.0-x64.exe][ptMachineX64] | 67B7E685AAF635803A87D8EE96CA1AF5024910B0BF00A9277CD77C810D049446 |
-| Machine wide - ARM64 | [PowerToysSetup-0.84.0-arm64.exe][ptMachineArm64] | 259DA1EFB33A616CF64840B8D8AB84F86A43F61687578B43849D5DE11F77AF82 |
+| Per user - x64       | [PowerToysUserSetup-0.84.1-x64.exe][ptUserX64] | 1CDAF3482B031D84DAE15188DE292FB44C5D211698089921040D94B256EBD3CA |
+| Per user - ARM64     | [PowerToysUserSetup-0.84.1-arm64.exe][ptUserArm64] | E0207EF5147EE281D4F438E87A30586D8CAA24DE948950FF1B12E05454622CD9 |
+| Machine wide - x64   | [PowerToysSetup-0.84.1-x64.exe][ptMachineX64] | 10DF9774DE1857051E135B9790A18A92C5C7F42587C733DEE991186E67231EE0 |
+| Machine wide - ARM64 | [PowerToysSetup-0.84.1-arm64.exe][ptMachineArm64] | EB5DDA5EFBA17E813DBF24AFF668DDF5424ED3659234ABBC15441D478D812699 |
 
 This is our preferred method.
 

--- a/src/Common.Dotnet.CsWinRT.props
+++ b/src/Common.Dotnet.CsWinRT.props
@@ -2,6 +2,7 @@
 <!-- Some items may be set in Directory.Build.props in root -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <WindowsSdkPackageVersion>10.0.20348.38</WindowsSdkPackageVersion>
     <TargetFramework>net8.0-windows10.0.20348.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
@@ -33,4 +34,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" />
   </ItemGroup>
+
+  <!-- this may need to be removed on future CsWinRT upgrades-->
+  <Target Name="RemoveCsWinRTPackageAnalyzer" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="%(Analyzer.NuGetPackageId) == 'Microsoft.Windows.CsWinRT'" />	  
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Controls/AnimatedContentControl/AnimatedContentControl.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Controls/AnimatedContentControl/AnimatedContentControl.cs
@@ -9,7 +9,7 @@ namespace AdvancedPaste.Controls
 {
     [TemplatePart(Name = LoadingGrid, Type = typeof(Grid))]
     [TemplatePart(Name = LoadingBrush, Type = typeof(AnimatedBorderBrush))]
-    public class AnimatedContentControl : ContentControl
+    public partial class AnimatedContentControl : ContentControl
     {
         internal const string LoadingGrid = "PART_LoadingGrid";
         internal const string LoadingBrush = "PART_LoadingBrush";

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Converters/CountToDoubleConverter.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Converters/CountToDoubleConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace AdvancedPaste.Converters;
 
-public sealed class CountToDoubleConverter : IValueConverter
+public sealed partial class CountToDoubleConverter : IValueConverter
 {
     public double ValueIfZero { get; set; }
 

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Converters/CountToVisibilityConverter.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Converters/CountToVisibilityConverter.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace AdvancedPaste.Converters;
 
-public sealed class CountToVisibilityConverter : IValueConverter
+public sealed partial class CountToVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToBoolConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToBoolConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace EnvironmentVariablesUILib.Converters;
 
-public class EnvironmentStateToBoolConverter : IValueConverter
+public partial class EnvironmentStateToBoolConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToMessageConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToMessageConverter.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace EnvironmentVariablesUILib.Converters;
 
-public class EnvironmentStateToMessageConverter : IValueConverter
+public partial class EnvironmentStateToMessageConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToTitleConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToTitleConverter.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace EnvironmentVariablesUILib.Converters;
 
-public class EnvironmentStateToTitleConverter : IValueConverter
+public partial class EnvironmentStateToTitleConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToVisibilityConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToVisibilityConverter.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace EnvironmentVariablesUILib.Converters;
 
-public class EnvironmentStateToVisibilityConverter : IValueConverter
+public partial class EnvironmentStateToVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/VariableTypeToGlyphConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/VariableTypeToGlyphConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace EnvironmentVariablesUILib.Converters;
 
-public class VariableTypeToGlyphConverter : IValueConverter
+public partial class VariableTypeToGlyphConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/modules/FileLocksmith/FileLocksmithUI/Converters/FileCountConverter.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Converters/FileCountConverter.cs
@@ -4,11 +4,10 @@
 
 using System;
 using Microsoft.UI.Xaml.Data;
-using PowerToys.FileLocksmithLib.Interop;
 
 namespace PowerToys.FileLocksmithUI.Converters
 {
-    public sealed class FileCountConverter : IValueConverter
+    public sealed partial class FileCountConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/modules/FileLocksmith/FileLocksmithUI/Converters/FileListToDescriptionConverter.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Converters/FileListToDescriptionConverter.cs
@@ -5,11 +5,10 @@
 using System;
 using System.IO;
 using Microsoft.UI.Xaml.Data;
-using PowerToys.FileLocksmithLib.Interop;
 
 namespace PowerToys.FileLocksmithUI.Converters
 {
-    public sealed class FileListToDescriptionConverter : IValueConverter
+    public sealed partial class FileListToDescriptionConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/modules/FileLocksmith/FileLocksmithUI/Converters/PidToIconConverter.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Converters/PidToIconConverter.cs
@@ -7,11 +7,10 @@ using System.Drawing;
 using System.IO;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Windows.Storage;
 
 namespace PowerToys.FileLocksmithUI.Converters
 {
-    public sealed class PidToIconConverter : IValueConverter
+    public sealed partial class PidToIconConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/modules/FileLocksmith/FileLocksmithUI/Converters/UserToSystemWarningVisibilityConverter.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Converters/UserToSystemWarningVisibilityConverter.cs
@@ -3,14 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
-using PowerToys.FileLocksmithLib.Interop;
 
 namespace PowerToys.FileLocksmithUI.Converters
 {
-    public sealed class UserToSystemWarningVisibilityConverter : IValueConverter
+    public sealed partial class UserToSystemWarningVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/modules/MeasureTool/MeasureToolCore/PowerToys.MeasureToolCore.vcxproj
+++ b/src/modules/MeasureTool/MeasureToolCore/PowerToys.MeasureToolCore.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.props')" />
+  <Import Project="..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
@@ -141,7 +141,8 @@
     <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
     <Import Project="..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.targets')" />
-    <Import Project="..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.targets')" />
+    <Import Project="..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets')" />
+    <Import Project="..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -152,7 +153,8 @@
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
 </Project>

--- a/src/modules/MeasureTool/MeasureToolCore/packages.config
+++ b/src/modules/MeasureTool/MeasureToolCore/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Web.WebView2" version="1.0.2739.15" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.22621.2428" targetFramework="native" />
-  <package id="Microsoft.WindowsAppSDK" version="1.5.240428000" targetFramework="native" />
+  <package id="Microsoft.WindowsAppSDK" version="1.6.240829007" targetFramework="native" />
 </packages>

--- a/src/modules/MeasureTool/MeasureToolUI/MeasureToolXAML/MainWindow.xaml.cs
+++ b/src/modules/MeasureTool/MeasureToolUI/MeasureToolXAML/MainWindow.xaml.cs
@@ -56,6 +56,11 @@ namespace MeasureToolUI
             this.SetIsMaximizable(false);
             IsTitleBarVisible = false;
 
+            // Remove the caption style from the window style. Windows App SDK 1.6 added it, which made the title bar and borders appear for Measure Tool. This code removes it.
+            var windowStyle = GetWindowLong(hwnd, GWL_STYLE);
+            windowStyle = windowStyle & (~WS_CAPTION);
+            _ = SetWindowLong(hwnd, GWL_STYLE, windowStyle);
+
             _coreLogic = core;
             Closed += MainWindow_Closed;
             DisplayArea displayArea = DisplayArea.GetFromWindowId(windowId, DisplayAreaFallback.Nearest);

--- a/src/modules/MeasureTool/MeasureToolUI/NativeMethods.cs
+++ b/src/modules/MeasureTool/MeasureToolUI/NativeMethods.cs
@@ -15,4 +15,13 @@ internal static class NativeMethods
     internal const uint SWP_NOMOVE = 0x0002;
     internal const uint SWP_NOACTIVATE = 0x0010;
     internal const uint SWP_SHOWWINDOW = 0x0040;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    internal static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll")]
+    internal static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+    internal const int GWL_STYLE = -16;
+    internal const int WS_CAPTION = 0x00C00000;
 }

--- a/src/modules/cmdpal/.vsconfig
+++ b/src/modules/cmdpal/.vsconfig
@@ -17,8 +17,6 @@
     "Microsoft.VisualStudio.Component.NuGet",
     "Microsoft.Component.ClickOnce",
     "Microsoft.VisualStudio.Component.ManagedDesktop.Core",
-    "Microsoft.NetCore.Component.Runtime.6.0",
-    "Microsoft.NetCore.Component.Runtime.7.0",
     "Microsoft.NetCore.Component.SDK",
     "Microsoft.VisualStudio.Component.FSharp",
     "Microsoft.ComponentGroup.ClickOnce.Publish",
@@ -39,7 +37,7 @@
     "Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs",
     "Microsoft.ComponentGroup.Blend",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
-    "Microsoft.VisualStudio.Component.Windows11SDK.22000",
+    "Microsoft.VisualStudio.Component.Windows10SDK.20348",
     "Microsoft.VisualStudio.Component.Windows10SDK.19041"
   ]
 }

--- a/src/modules/cmdpal/Exts/HackerNewsExtension/CommentAction.cs
+++ b/src/modules/cmdpal/Exts/HackerNewsExtension/CommentAction.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace HackerNewsExtension;
 
-internal sealed class CommentAction : InvokableCommand
+internal sealed partial class CommentAction : InvokableCommand
 {
     private readonly NewsPost _post;
 

--- a/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsActionsProvider.cs
+++ b/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsActionsProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace HackerNewsExtension;
 
-public class HackerNewsActionsProvider : ICommandProvider
+public partial class HackerNewsActionsProvider : ICommandProvider
 {
     public string DisplayName => $"Hacker News Commands";
 

--- a/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsPage.cs
+++ b/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsPage.cs
@@ -13,7 +13,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace HackerNewsExtension;
 
-internal sealed class HackerNewsPage : ListPage
+internal sealed partial class HackerNewsPage : ListPage
 {
     public HackerNewsPage()
     {

--- a/src/modules/cmdpal/Exts/HackerNewsExtension/LinkAction.cs
+++ b/src/modules/cmdpal/Exts/HackerNewsExtension/LinkAction.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace HackerNewsExtension;
 
-internal sealed class LinkAction : InvokableCommand
+internal sealed partial class LinkAction : InvokableCommand
 {
     private readonly NewsPost _post;
 

--- a/src/modules/cmdpal/Exts/HackerNewsExtension/SampleExtension.cs
+++ b/src/modules/cmdpal/Exts/HackerNewsExtension/SampleExtension.cs
@@ -12,7 +12,7 @@ namespace HackerNewsExtension;
 [ComVisible(true)]
 [Guid("283DDB0F-1AD9-406F-B359-699BFBD2DA68")]
 [ComDefaultInterface(typeof(IExtension))]
-public sealed class SampleExtension : IExtension
+public sealed partial class SampleExtension : IExtension
 {
     private readonly ManualResetEvent _extensionDisposedEvent;
 

--- a/src/modules/cmdpal/Exts/MastodonExtension/MastodonExtensionPage.cs
+++ b/src/modules/cmdpal/Exts/MastodonExtension/MastodonExtensionPage.cs
@@ -9,7 +9,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 namespace MastodonExtension;
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "This is sample code")]
-internal sealed class MastodonExtensionPage : ListPage
+internal sealed partial class MastodonExtensionPage : ListPage
 {
     public MastodonExtensionPage()
     {
@@ -31,7 +31,7 @@ internal sealed class MastodonExtensionPage : ListPage
 }
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "This is sample code")]
-public class MastodonExtensionActionsProvider : ICommandProvider
+public partial class MastodonExtensionActionsProvider : ICommandProvider
 {
     public string DisplayName => $"Mastodon extension for cmdpal Commands";
 

--- a/src/modules/cmdpal/Exts/MastodonExtension/SampleExtension.cs
+++ b/src/modules/cmdpal/Exts/MastodonExtension/SampleExtension.cs
@@ -12,7 +12,7 @@ namespace MastodonExtension;
 [ComVisible(true)]
 [Guid("f0e93f1a-2b64-4896-abcc-8d2145480ede")]
 [ComDefaultInterface(typeof(IExtension))]
-public sealed class SampleExtension : IExtension
+public sealed partial class SampleExtension : IExtension
 {
     private readonly ManualResetEvent _extensionDisposedEvent;
 

--- a/src/modules/cmdpal/Exts/MediaControlsExtension/MediaActionsProvider.cs
+++ b/src/modules/cmdpal/Exts/MediaControlsExtension/MediaActionsProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions;
 
 namespace MediaControlsExtension;
 
-public class MediaActionsProvider : ICommandProvider
+public partial class MediaActionsProvider : ICommandProvider
 {
     public string DisplayName => $"Media controls actions";
 

--- a/src/modules/cmdpal/Exts/MediaControlsExtension/MediaListItem.cs
+++ b/src/modules/cmdpal/Exts/MediaControlsExtension/MediaListItem.cs
@@ -9,7 +9,7 @@ using Windows.Media.Control;
 
 namespace MediaControlsExtension;
 
-internal sealed class MediaListItem : ListItem
+internal sealed partial class MediaListItem : ListItem
 {
     private GlobalSystemMediaTransportControlsSession _mediaSession;
 

--- a/src/modules/cmdpal/Exts/MediaControlsExtension/PrevNextTrackAction.cs
+++ b/src/modules/cmdpal/Exts/MediaControlsExtension/PrevNextTrackAction.cs
@@ -8,7 +8,7 @@ using Windows.Media.Control;
 
 namespace MediaControlsExtension;
 
-internal sealed class PrevNextTrackAction : InvokableCommand
+internal sealed partial class PrevNextTrackAction : InvokableCommand
 {
     private readonly GlobalSystemMediaTransportControlsSession _mediaSession;
     private readonly bool _previous;

--- a/src/modules/cmdpal/Exts/MediaControlsExtension/SampleExtension.cs
+++ b/src/modules/cmdpal/Exts/MediaControlsExtension/SampleExtension.cs
@@ -12,7 +12,7 @@ namespace MediaControlsExtension;
 [ComVisible(true)]
 [Guid("bb60a98a-0197-4378-9b40-b684f4068d1d")]
 [ComDefaultInterface(typeof(IExtension))]
-public sealed class SampleExtension : IExtension
+public sealed partial class SampleExtension : IExtension
 {
     private readonly ManualResetEvent _extensionDisposedEvent;
 

--- a/src/modules/cmdpal/Exts/MediaControlsExtension/TogglePlayMediaAction.cs
+++ b/src/modules/cmdpal/Exts/MediaControlsExtension/TogglePlayMediaAction.cs
@@ -7,7 +7,7 @@ using Windows.Media.Control;
 
 namespace MediaControlsExtension;
 
-public sealed class TogglePlayMediaAction : InvokableCommand
+public sealed partial class TogglePlayMediaAction : InvokableCommand
 {
     public GlobalSystemMediaTransportControlsSession MediaSession { get; set; }
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkForm.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkForm.cs
@@ -10,7 +10,7 @@ using Windows.Foundation;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-internal sealed class AddBookmarkForm : Form
+internal sealed partial class AddBookmarkForm : Form
 {
     internal event TypedEventHandler<object, object?>? AddedAction;
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkPage.cs
@@ -8,7 +8,7 @@ using Windows.Foundation;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-internal sealed class AddBookmarkPage : FormPage
+internal sealed partial class AddBookmarkPage : FormPage
 {
     private readonly AddBookmarkForm _addBookmark = new();
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderForm.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderForm.cs
@@ -12,7 +12,7 @@ using Windows.System;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-internal sealed class BookmarkPlaceholderForm : Form
+internal sealed partial class BookmarkPlaceholderForm : Form
 {
     private readonly List<string> _placeholderNames;
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderPage.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-internal sealed class BookmarkPlaceholderPage : FormPage
+internal sealed partial class BookmarkPlaceholderPage : FormPage
 {
     private readonly IForm _bookmarkPlaceholder;
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarksCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarksCommandProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-public class BookmarksCommandProvider : ICommandProvider
+public partial class BookmarksCommandProvider : ICommandProvider
 {
     public string DisplayName => $"Bookmarks";
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/OpenInTerminalAction.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/OpenInTerminalAction.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-internal sealed class OpenInTerminalAction : InvokableCommand
+internal sealed partial class OpenInTerminalAction : InvokableCommand
 {
     private readonly string _folder;
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/UrlAction.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/UrlAction.cs
@@ -8,7 +8,7 @@ using Windows.System;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-public class UrlAction : InvokableCommand
+public partial class UrlAction : InvokableCommand
 {
     private bool IsContainsPlaceholder => _url.Contains('{') && _url.Contains('}');
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorAction.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorAction.cs
@@ -10,7 +10,7 @@ using Windows.ApplicationModel.DataTransfer;
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 namespace Microsoft.CmdPal.Ext.Calc;
 
-public class CalculatorAction : InvokableCommand
+public partial class CalculatorAction : InvokableCommand
 {
     private bool _success;
     private string _result = string.Empty;

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
@@ -9,7 +9,7 @@ using Microsoft.CmdPal.Extensions;
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 namespace Microsoft.CmdPal.Ext.Calc;
 
-public class CalculatorCommandProvider : ICommandProvider
+public partial class CalculatorCommandProvider : ICommandProvider
 {
     public string DisplayName => $"Calculator";
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorTopLevelListItem.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorTopLevelListItem.cs
@@ -11,7 +11,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 namespace Microsoft.CmdPal.Ext.Calc;
 
-public class CalculatorTopLevelListItem : ListItem, IFallbackHandler
+public partial class CalculatorTopLevelListItem : ListItem, IFallbackHandler
 {
     public CalculatorTopLevelListItem()
         : base(new CalculatorAction())

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.CmdPalSettings/SettingsCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.CmdPalSettings/SettingsCommandProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Settings;
 
-public class SettingsCommandProvider : ICommandProvider
+public partial class SettingsCommandProvider : ICommandProvider
 {
     public string DisplayName => $"Settings";
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.CmdPalSettings/SettingsForm.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.CmdPalSettings/SettingsForm.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Settings;
 
-internal sealed class SettingsForm : Form
+internal sealed partial class SettingsForm : Form
 {
     public SettingsForm()
     {

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.CmdPalSettings/SettingsPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.CmdPalSettings/SettingsPage.cs
@@ -9,7 +9,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 namespace Microsoft.CmdPal.Ext.Settings;
 
-internal sealed class SettingsPage : FormPage
+internal sealed partial class SettingsPage : FormPage
 {
     private readonly SettingsForm _settings = new();
 

--- a/src/modules/cmdpal/Exts/ProcessMonitorExtension/ProcessListPage.cs
+++ b/src/modules/cmdpal/Exts/ProcessMonitorExtension/ProcessListPage.cs
@@ -11,7 +11,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace ProcessMonitorExtension;
 
-internal sealed class ProcessListPage : ListPage
+internal sealed partial class ProcessListPage : ListPage
 {
     public ProcessListPage()
     {

--- a/src/modules/cmdpal/Exts/ProcessMonitorExtension/ProcessMonitorCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/ProcessMonitorExtension/ProcessMonitorCommandProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace ProcessMonitorExtension;
 
-internal sealed class ProcessMonitorCommandProvider : ICommandProvider
+internal sealed partial class ProcessMonitorCommandProvider : ICommandProvider
 {
     public string DisplayName => "Process Monitor Commands";
 

--- a/src/modules/cmdpal/Exts/ProcessMonitorExtension/SampleExtension.cs
+++ b/src/modules/cmdpal/Exts/ProcessMonitorExtension/SampleExtension.cs
@@ -12,7 +12,7 @@ namespace ProcessMonitorExtension;
 [ComVisible(true)]
 [Guid("8BD7A6C4-7185-4426-AE8D-61E438A3E740")]
 [ComDefaultInterface(typeof(IExtension))]
-public sealed class SampleExtension : IExtension
+public sealed partial class SampleExtension : IExtension
 {
     private readonly ManualResetEvent _extensionDisposedEvent;
 

--- a/src/modules/cmdpal/Exts/ProcessMonitorExtension/SwitchToProcess.cs
+++ b/src/modules/cmdpal/Exts/ProcessMonitorExtension/SwitchToProcess.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace ProcessMonitorExtension;
 
-internal sealed class SwitchToProcess : InvokableCommand
+internal sealed partial class SwitchToProcess : InvokableCommand
 {
     [DllImport("user32.dll")]
     public static extern void SwitchToThisWindow(IntPtr hWnd, bool fAltTab);

--- a/src/modules/cmdpal/Exts/ProcessMonitorExtension/TerminateProcess.cs
+++ b/src/modules/cmdpal/Exts/ProcessMonitorExtension/TerminateProcess.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace ProcessMonitorExtension;
 
-internal sealed class TerminateProcess : InvokableCommand
+internal sealed partial class TerminateProcess : InvokableCommand
 {
     private readonly ProcessItem _process;
 

--- a/src/modules/cmdpal/Exts/SSHKeychainExtension/Commands/LaunchSSHHostCommand.cs
+++ b/src/modules/cmdpal/Exts/SSHKeychainExtension/Commands/LaunchSSHHostCommand.cs
@@ -14,7 +14,7 @@ using SSHKeychainExtension.Data;
 
 namespace SSHKeychainExtension.Commands;
 
-internal sealed class LaunchSSHHostCommand : InvokableCommand
+internal sealed partial class LaunchSSHHostCommand : InvokableCommand
 {
     private readonly SSHKeychainItem _host;
 

--- a/src/modules/cmdpal/Exts/SSHKeychainExtension/CommentAction.cs
+++ b/src/modules/cmdpal/Exts/SSHKeychainExtension/CommentAction.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SSHKeychainExtension;
 
-internal sealed class CommentAction : InvokableCommand
+internal sealed partial class CommentAction : InvokableCommand
 {
     private readonly NewsPost _post;
 

--- a/src/modules/cmdpal/Exts/SSHKeychainExtension/LinkAction.cs
+++ b/src/modules/cmdpal/Exts/SSHKeychainExtension/LinkAction.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SSHKeychainExtension;
 
-internal sealed class LinkAction : InvokableCommand
+internal sealed partial class LinkAction : InvokableCommand
 {
     private readonly NewsPost _post;
 

--- a/src/modules/cmdpal/Exts/SSHKeychainExtension/Pages/SSHHostsListPage.cs
+++ b/src/modules/cmdpal/Exts/SSHKeychainExtension/Pages/SSHHostsListPage.cs
@@ -20,7 +20,7 @@ using SSHKeychainExtension.Data;
 
 namespace SSHKeychainExtension;
 
-internal sealed class SSHHostsListPage : ListPage
+internal sealed partial class SSHHostsListPage : ListPage
 {
     private static readonly string _defaultConfigFile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + "\\.ssh\\config";
 

--- a/src/modules/cmdpal/Exts/SSHKeychainExtension/SSHKeychainCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/SSHKeychainExtension/SSHKeychainCommandsProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SSHKeychainExtension;
 
-public class SSHKeychainCommandsProvider : ICommandProvider
+public partial class SSHKeychainCommandsProvider : ICommandProvider
 {
     public string DisplayName => $"SSH Keychain Commands";
 

--- a/src/modules/cmdpal/Exts/SSHKeychainExtension/SampleExtension.cs
+++ b/src/modules/cmdpal/Exts/SSHKeychainExtension/SampleExtension.cs
@@ -12,7 +12,7 @@ namespace SSHKeychainExtension;
 [ComVisible(true)]
 [Guid("D07A5785-2334-4686-9A49-AE19D992284F")]
 [ComDefaultInterface(typeof(IExtension))]
-public sealed class SampleExtension : IExtension
+public sealed partial class SampleExtension : IExtension
 {
     private readonly ManualResetEvent _extensionDisposedEvent;
 

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Forms/SampleForm.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Forms/SampleForm.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SamplePagesExtension;
 
-internal sealed class SampleForm : Form
+internal sealed partial class SampleForm : Form
 {
     public SampleForm()
     {

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleDynamicListPage.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleDynamicListPage.cs
@@ -18,7 +18,7 @@ using Microsoft.UI.Windowing;
 
 namespace SamplePagesExtension;
 
-internal sealed class SampleDynamicListPage : DynamicListPage
+internal sealed partial class SampleDynamicListPage : DynamicListPage
 {
     public SampleDynamicListPage()
     {

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleFormPage.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleFormPage.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SamplePagesExtension;
 
-internal sealed class SampleFormPage : FormPage
+internal sealed partial class SampleFormPage : FormPage
 {
     private readonly SampleForm sampleForm = new();
 

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPage.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPage.cs
@@ -18,7 +18,7 @@ using Microsoft.UI.Windowing;
 
 namespace SamplePagesExtension;
 
-internal sealed class SampleListPage : ListPage
+internal sealed partial class SampleListPage : ListPage
 {
     public SampleListPage()
     {

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPageWithDetails.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPageWithDetails.cs
@@ -18,7 +18,7 @@ using Microsoft.UI.Windowing;
 
 namespace SamplePagesExtension;
 
-internal sealed class SampleListPageWithDetails : ListPage
+internal sealed partial class SampleListPageWithDetails : ListPage
 {
     public SampleListPageWithDetails()
     {

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleMarkdownPage.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleMarkdownPage.cs
@@ -18,7 +18,7 @@ using Microsoft.UI.Windowing;
 
 namespace SamplePagesExtension;
 
-internal sealed class SampleMarkdownPage : MarkdownPage
+internal sealed partial class SampleMarkdownPage : MarkdownPage
 {
     private readonly string _markdown = @"
 # Markdown Guide

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/SampleExtension.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/SampleExtension.cs
@@ -12,7 +12,7 @@ namespace SamplePagesExtension;
 [ComVisible(true)]
 [Guid("6112D28D-6341-45C8-92C3-83ED55853A9F")]
 [ComDefaultInterface(typeof(IExtension))]
-public sealed class SampleExtension : IExtension
+public sealed partial class SampleExtension : IExtension
 {
     private readonly ManualResetEvent _extensionDisposedEvent;
 

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/SamplePagesCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/SamplePagesCommandsProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SamplePagesExtension;
 
-public class SamplePagesCommandsProvider : ICommandProvider
+public partial class SamplePagesCommandsProvider : ICommandProvider
 {
     public string DisplayName => $"Sample Pages Commands";
 

--- a/src/modules/cmdpal/Exts/SpongebotExtension/CopyTextAction.cs
+++ b/src/modules/cmdpal/Exts/SpongebotExtension/CopyTextAction.cs
@@ -8,7 +8,7 @@ using Windows.ApplicationModel.DataTransfer;
 
 namespace SpongebotExtension;
 
-public class CopyTextAction : InvokableCommand
+public partial class CopyTextAction : InvokableCommand
 {
     internal string Text { get; set; }
 

--- a/src/modules/cmdpal/Exts/SpongebotExtension/SampleExtension.cs
+++ b/src/modules/cmdpal/Exts/SpongebotExtension/SampleExtension.cs
@@ -12,7 +12,7 @@ namespace SpongebotExtension;
 [ComVisible(true)]
 [Guid("a50859fc-a214-4852-b47b-62ada70df7bc")]
 [ComDefaultInterface(typeof(IExtension))]
-public sealed class SampleExtension : IExtension
+public sealed partial class SampleExtension : IExtension
 {
     private readonly ManualResetEvent _extensionDisposedEvent;
 

--- a/src/modules/cmdpal/Exts/SpongebotExtension/SpongeSettingsForm.cs
+++ b/src/modules/cmdpal/Exts/SpongebotExtension/SpongeSettingsForm.cs
@@ -10,7 +10,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SpongebotExtension;
 
-internal sealed class SpongeSettingsForm : Form
+internal sealed partial class SpongeSettingsForm : Form
 {
     public override string TemplateJson()
     {

--- a/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotCommandsProvider.cs
@@ -9,7 +9,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SpongebotExtension;
 
-internal sealed class SpongebotCommandsProvider : ICommandProvider
+internal sealed partial class SpongebotCommandsProvider : ICommandProvider
 {
     public string DisplayName => $"Spongebob, mocking";
 

--- a/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotPage.cs
+++ b/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotPage.cs
@@ -12,7 +12,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SpongebotExtension;
 
-public class SpongebotPage : MarkdownPage, IFallbackHandler
+public partial class SpongebotPage : MarkdownPage, IFallbackHandler
 {
     public CopyTextAction CopyTextAction { get; set; } = new(string.Empty);
 

--- a/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotSettingsPage.cs
+++ b/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotSettingsPage.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SpongebotExtension;
 
-internal sealed class SpongebotSettingsPage : FormPage
+internal sealed partial class SpongebotSettingsPage : FormPage
 {
     private readonly SpongeSettingsForm settingsForm = new();
 

--- a/src/modules/cmdpal/Exts/TemplateExtension/SampleExtension.cs
+++ b/src/modules/cmdpal/Exts/TemplateExtension/SampleExtension.cs
@@ -12,7 +12,7 @@ namespace TemplateExtension;
 [ComVisible(true)]
 [Guid("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")]
 [ComDefaultInterface(typeof(IExtension))]
-public sealed class SampleExtension : IExtension
+public sealed partial class SampleExtension : IExtension
 {
     private readonly ManualResetEvent _extensionDisposedEvent;
 

--- a/src/modules/cmdpal/Exts/TemplateExtension/TemplateExtensionPage.cs
+++ b/src/modules/cmdpal/Exts/TemplateExtension/TemplateExtensionPage.cs
@@ -9,7 +9,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 namespace TemplateExtension;
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "This is sample code")]
-internal sealed class TemplateExtensionPage : ListPage
+internal sealed partial class TemplateExtensionPage : ListPage
 {
     public TemplateExtensionPage()
     {
@@ -31,7 +31,7 @@ internal sealed class TemplateExtensionPage : ListPage
 }
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "This is sample code")]
-public class TemplateExtensionActionsProvider : ICommandProvider
+public partial class TemplateExtensionActionsProvider : ICommandProvider
 {
     public string DisplayName => $"TemplateDisplayName Commands";
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Microsoft.CmdPal.Common.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Microsoft.CmdPal.Common.csproj
@@ -15,6 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="Microsoft.Web.WebView2" /> <!-- This line forces the WebView2 version used by Windows App SDK to be the one we expect from Directory.Packages.props . -->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/cmdpal/Microsoft.Terminal.UI/Microsoft.Terminal.UI.vcxproj
+++ b/src/modules/cmdpal/Microsoft.Terminal.UI/Microsoft.Terminal.UI.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PathToRoot>..\..\..\..\</PathToRoot>
-    <WasdkNuget>$(PathToRoot)packages\Microsoft.WindowsAppSDK.1.5.240428000</WasdkNuget>
+    <WasdkNuget>$(PathToRoot)packages\Microsoft.WindowsAppSDK.1.6.240829007</WasdkNuget>
     <CppWinRTNuget>$(PathToRoot)packages\Microsoft.Windows.CppWinRT.2.0.240111.5</CppWinRTNuget>
   </PropertyGroup>
   <Import Project="$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.props')" />

--- a/src/modules/cmdpal/Microsoft.Terminal.UI/Microsoft.Terminal.UI.vcxproj
+++ b/src/modules/cmdpal/Microsoft.Terminal.UI/Microsoft.Terminal.UI.vcxproj
@@ -4,6 +4,7 @@
     <PathToRoot>..\..\..\..\</PathToRoot>
     <WasdkNuget>$(PathToRoot)packages\Microsoft.WindowsAppSDK.1.6.240829007</WasdkNuget>
     <CppWinRTNuget>$(PathToRoot)packages\Microsoft.Windows.CppWinRT.2.0.240111.5</CppWinRTNuget>
+    <WebView2Nuget>$(PathToRoot)packages\Microsoft.Web.WebView2.1.0.2739.15</WebView2Nuget>
   </PropertyGroup>
   <Import Project="$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="$(CppWinRTNuget)\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(CppWinRTNuget)\build\native\Microsoft.Windows.CppWinRT.props')" />
@@ -188,6 +189,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(CppWinRTNuget)\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(CppWinRTNuget)\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.targets')" />
+    <Import Project="$(WebView2Nuget)\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('$(WebView2Nuget)\build\native\Microsoft.Web.WebView2.targets')" />
     <Import Project="..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(MSBuildThisFileDirectory)..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -198,6 +200,7 @@
     <Error Condition="!Exists('$(CppWinRTNuget)\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(CppWinRTNuget)\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.props'))" />
     <Error Condition="!Exists('$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.targets'))" />
+    <Error Condition="!Exists('$(WebView2Nuget)\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(WebView2Nuget)\build\native\Microsoft.Web.WebView2.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', 'Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
   <ItemGroup>

--- a/src/modules/cmdpal/Microsoft.Terminal.UI/packages.config
+++ b/src/modules/cmdpal/Microsoft.Terminal.UI/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- The packages.config acts as the global version for all of the NuGet packages contained within. -->
 <packages>
+  <package id="Microsoft.Web.WebView2" version="1.0.2739.15" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" developmentDependency="true" />
 </packages>

--- a/src/modules/cmdpal/WindowsCommandPalette/Builtins/Apps/AllAppsPage.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Builtins/Apps/AllAppsPage.cs
@@ -10,7 +10,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace WindowsCommandPalette.BuiltinCommands.AllApps;
 
-public sealed class AllAppsPage : ListPage
+public sealed partial class AllAppsPage : ListPage
 {
     private ISection allAppsSection = new ListSection();
 

--- a/src/modules/cmdpal/WindowsCommandPalette/Builtins/Apps/AppAction.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Builtins/Apps/AppAction.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace WindowsCommandPalette.BuiltinCommands.AllApps;
 
-internal sealed class AppAction : InvokableCommand
+internal sealed partial class AppAction : InvokableCommand
 {
     private readonly AppItem _app;
 

--- a/src/modules/cmdpal/WindowsCommandPalette/Builtins/Apps/AppListItem.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Builtins/Apps/AppListItem.cs
@@ -6,7 +6,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace WindowsCommandPalette.BuiltinCommands.AllApps;
 
-internal sealed class AppListItem : ListItem
+internal sealed partial class AppListItem : ListItem
 {
     private readonly AppItem _app;
 

--- a/src/modules/cmdpal/WindowsCommandPalette/Builtins/Apps/OpenPathAction.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Builtins/Apps/OpenPathAction.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 namespace WindowsCommandPalette.BuiltinCommands.AllApps;
 
 // NOTE this is pretty close to what we'd put in the SDK
-internal sealed class OpenPathAction(string target) : InvokableCommand
+internal sealed partial class OpenPathAction(string target) : InvokableCommand
 {
     private readonly string _target = target;
 

--- a/src/modules/cmdpal/WindowsCommandPalette/Builtins/QuitAction/QuitAction.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Builtins/QuitAction/QuitAction.cs
@@ -8,7 +8,7 @@ using Windows.Foundation;
 
 namespace WindowsCommandPalette.BuiltinCommands;
 
-public class QuitAction : InvokableCommand, IFallbackHandler
+public partial class QuitAction : InvokableCommand, IFallbackHandler
 {
     public event TypedEventHandler<object?, object?>? QuitRequested;
 

--- a/src/modules/cmdpal/WindowsCommandPalette/Builtins/QuitAction/QuitCommandProvider.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Builtins/QuitAction/QuitCommandProvider.cs
@@ -8,7 +8,7 @@ using Windows.Foundation;
 
 namespace WindowsCommandPalette.BuiltinCommands;
 
-public class QuitCommandProvider : ICommandProvider
+public partial class QuitCommandProvider : ICommandProvider
 {
     public string DisplayName => string.Empty;
 

--- a/src/modules/cmdpal/WindowsCommandPalette/Builtins/ReloadExtensionsAction.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Builtins/ReloadExtensionsAction.cs
@@ -8,7 +8,7 @@ using Windows.Foundation;
 
 namespace WindowsCommandPalette.BuiltinCommands;
 
-public class ReloadExtensionsAction : InvokableCommand, IFallbackHandler
+public partial class ReloadExtensionsAction : InvokableCommand, IFallbackHandler
 {
     public ReloadExtensionsAction()
     {

--- a/src/modules/cmdpal/WindowsCommandPalette/Builtins/ReloadExtensionsCommandProvider.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Builtins/ReloadExtensionsCommandProvider.cs
@@ -8,7 +8,7 @@ using Windows.Foundation;
 
 namespace WindowsCommandPalette.BuiltinCommands;
 
-public class ReloadExtensionsCommandProvider : ICommandProvider
+public partial class ReloadExtensionsCommandProvider : ICommandProvider
 {
     public string DisplayName => string.Empty;
 

--- a/src/modules/cmdpal/WindowsCommandPalette/FilteredListSection.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/FilteredListSection.cs
@@ -16,7 +16,7 @@ namespace DeveloperCommandPalette;
 
 // The FilteredListSection is for when we've got any filter at all. It starts by
 // enumerating all actions and apps, and returns the subset that matches.
-public sealed class FilteredListSection : ISection, INotifyCollectionChanged
+public sealed partial class FilteredListSection : ISection, INotifyCollectionChanged
 {
     public event NotifyCollectionChangedEventHandler? CollectionChanged;
 

--- a/src/modules/cmdpal/WindowsCommandPalette/MainListItem.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/MainListItem.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace DeveloperCommandPalette;
 
-public sealed class MainListItem : ListItem
+public sealed partial class MainListItem : ListItem
 {
     public IListItem Item { get; set; }
 

--- a/src/modules/cmdpal/WindowsCommandPalette/MainListPage.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/MainListPage.cs
@@ -10,7 +10,7 @@ using WindowsCommandPalette.Views;
 
 namespace DeveloperCommandPalette;
 
-public sealed class MainListPage : DynamicListPage
+public sealed partial class MainListPage : DynamicListPage
 {
     private readonly MainViewModel _mainViewModel;
     private readonly MainListSection _mainSection;

--- a/src/modules/cmdpal/WindowsCommandPalette/MainListSection.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/MainListSection.cs
@@ -11,7 +11,7 @@ using WindowsCommandPalette.Views;
 namespace DeveloperCommandPalette;
 
 // The MainListSection is for all non-recent actions. No apps.
-public sealed class MainListSection : ISection, INotifyCollectionChanged
+public sealed partial class MainListSection : ISection, INotifyCollectionChanged
 {
     public event NotifyCollectionChangedEventHandler? CollectionChanged;
 

--- a/src/modules/cmdpal/WindowsCommandPalette/RecentsListSection.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/RecentsListSection.cs
@@ -11,7 +11,7 @@ using WindowsCommandPalette.Views;
 
 namespace DeveloperCommandPalette;
 
-public sealed class RecentsListSection : ListSection, INotifyCollectionChanged
+public sealed partial class RecentsListSection : ListSection, INotifyCollectionChanged
 {
     public event NotifyCollectionChangedEventHandler? CollectionChanged;
 

--- a/src/modules/cmdpal/WindowsCommandPalette/Views/ErrorListItem.xaml.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Views/ErrorListItem.xaml.cs
@@ -6,7 +6,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace WindowsCommandPalette.Views;
 
-public sealed class ErrorListItem : ListItem
+public sealed partial class ErrorListItem : ListItem
 {
     public ErrorListItem(Exception ex)
         : base(new NoOpAction())

--- a/src/modules/cmdpal/WindowsCommandPalette/Views/NoOpAction.xaml.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Views/NoOpAction.xaml.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace WindowsCommandPalette.Views;
 
-public sealed class NoOpAction : InvokableCommand
+public sealed partial class NoOpAction : InvokableCommand
 {
     public override ICommandResult Invoke()
     {

--- a/src/modules/cmdpal/WindowsCommandPalette/Views/StringNotEmptyToVisibilityConverter.xaml.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Views/StringNotEmptyToVisibilityConverter.xaml.cs
@@ -7,7 +7,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace WindowsCommandPalette.Views;
 
-public sealed class StringNotEmptyToVisibilityConverter : IValueConverter
+public sealed partial class StringNotEmptyToVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Microsoft.CmdPal.Extensions.Helpers.csproj
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Microsoft.CmdPal.Extensions.Helpers.csproj
@@ -23,6 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
+    <PackageReference Include="Microsoft.Web.WebView2" /> <!-- This line forces the WebView2 version used by Windows App SDK to be the one we expect from Directory.Packages.props . -->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.vcxproj
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PathToRoot>..\..\..\..\..\</PathToRoot>
-    <WasdkNuget>$(PathToRoot)packages\Microsoft.WindowsAppSDK.1.5.240428000</WasdkNuget>
+    <WasdkNuget>$(PathToRoot)packages\Microsoft.WindowsAppSDK.1.6.240829007</WasdkNuget>
     <CppWinRTNuget>$(PathToRoot)packages\Microsoft.Windows.CppWinRT.2.0.240111.5</CppWinRTNuget>
     <WindowsSdkBuildToolsNuget>$(PathToRoot)packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428</WindowsSdkBuildToolsNuget>
   </PropertyGroup>

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.vcxproj
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.vcxproj
@@ -5,6 +5,7 @@
     <WasdkNuget>$(PathToRoot)packages\Microsoft.WindowsAppSDK.1.6.240829007</WasdkNuget>
     <CppWinRTNuget>$(PathToRoot)packages\Microsoft.Windows.CppWinRT.2.0.240111.5</CppWinRTNuget>
     <WindowsSdkBuildToolsNuget>$(PathToRoot)packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428</WindowsSdkBuildToolsNuget>
+    <WebView2Nuget>$(PathToRoot)packages\Microsoft.Web.WebView2.1.0.2739.15</WebView2Nuget>
   </PropertyGroup>
 
   <Import Project="$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.props')" />
@@ -171,6 +172,7 @@
     <Import Project="$(WindowsSdkBuildToolsNuget)\build\Microsoft.Windows.SDK.BuildTools.targets" Condition="Exists('$(WindowsSdkBuildToolsNuget)\build\Microsoft.Windows.SDK.BuildTools.targets')" />
     <Import Project="$(CppWinRTNuget)\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(CppWinRTNuget)\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.targets')" />
+    <Import Project="$(WebView2Nuget)\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('$(WebView2Nuget)\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -182,6 +184,7 @@
     <Error Condition="!Exists('$(CppWinRTNuget)\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(CppWinRTNuget)\build\native\Microsoft.Windows.CppWinRT.targets'))" />
     <Error Condition="!Exists('$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.props'))" />
     <Error Condition="!Exists('$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(WasdkNuget)\build\native\Microsoft.WindowsAppSDK.targets'))" />
+    <Error Condition="!Exists('$(WebView2Nuget)\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(WebView2Nuget)\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
   <ItemGroup>
     <ResourceCompile Include="version.rc" />

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/packages.config
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Web.WebView2" version="1.0.2739.15" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.22621.2428" targetFramework="native" />
   <package id="Microsoft.WindowsAppSDK" version="1.6.240829007" targetFramework="native" />

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/packages.config
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.22621.2428" targetFramework="native" />
-  <package id="Microsoft.WindowsAppSDK" version="1.5.240428000" targetFramework="native" />
+  <package id="Microsoft.WindowsAppSDK" version="1.6.240829007" targetFramework="native" />
 </packages>

--- a/src/modules/cmdpal/extensionsdk/nuget/Microsoft.Windows.CommandPalette.Extensions.nuspec
+++ b/src/modules/cmdpal/extensionsdk/nuget/Microsoft.Windows.CommandPalette.Extensions.nuspec
@@ -15,7 +15,7 @@
     <projectUrl>https://github.com/microsoft/powertoys</projectUrl> <!-- TODO!: make repo lmao -->
     <dependencies>
       <group targetFramework="net8.0-windows10.0.19041.0">
-        <dependency id="Microsoft.Windows.CsWinRT" version="2.0.1" />
+        <dependency id="Microsoft.Windows.CsWinRT" version="2.1.1" />
       </group>
     </dependencies>
   </metadata>

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.vcxproj
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.vcxproj
@@ -162,7 +162,7 @@
     <Import Project="..\..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" />
     <Import Project="..\..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.7\build\native\Microsoft.VCRTForwarders.140.targets" Condition="Exists('..\..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.7\build\native\Microsoft.VCRTForwarders.140.targets')" />
     <Import Project="..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets')" />
-    <Import Project="..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Import Project="..\..\..\..\deps\spdlog.props" />
   <Target Name="GenerateResourceFiles" BeforeTargets="PrepareForBuild">
@@ -179,7 +179,7 @@
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.7\build\native\Microsoft.VCRTForwarders.140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.VCRTForwarders.140.1.0.7\build\native\Microsoft.VCRTForwarders.140.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
   <Target Name="FakeResourcesPriMerge" BeforeTargets="FinalizeBuildStatus" DependsOnTargets="CopyFilesToOutputDirectory">
     <Message Text="Renaming Microsoft.UI.Xaml.pri to resources.pri" />

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/packages.config
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.8.2-prerelease.220830001" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.7" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="1.0.2365.46" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.2739.15" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
 </packages>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyboardManagerEditorLibrary.vcxproj
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyboardManagerEditorLibrary.vcxproj
@@ -101,7 +101,7 @@
     <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" />
     <Import Project="..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets')" />
-    <Import Project="..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Import Project="..\..\..\..\deps\spdlog.props" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -114,7 +114,7 @@
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.UI.Xaml.2.8.2-prerelease.220830001\build\native\Microsoft.UI.Xaml.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
   <Target Name="GenerateResourceFiles" BeforeTargets="PrepareForBuild">
     <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted $(SolutionDir)tools\build\convert-resx-to-rc.ps1 $(MSBuildThisFileDirectory)\..\KeyboardManagerEditor\ resource.base.h resource.h KeyboardManagerEditor.base.rc KeyboardManagerEditor.rc" />

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/packages.config
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.8.2-prerelease.220830001" targetFramework="native" />
-  <package id="Microsoft.Web.WebView2" version="1.0.2365.46" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.2739.15" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
 </packages>

--- a/src/modules/peek/Peek.Common/Converters/BytesToStringConverter.cs
+++ b/src/modules/peek/Peek.Common/Converters/BytesToStringConverter.cs
@@ -8,7 +8,7 @@ using Peek.Common.Helpers;
 
 namespace Peek.Common.Converters
 {
-    public class BytesToStringConverter : IValueConverter
+    public partial class BytesToStringConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Archives/Models/ArchiveItemTemplateSelector.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Archives/Models/ArchiveItemTemplateSelector.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Peek.FilePreviewer.Previewers.Archives.Models
 {
-    public class ArchiveItemTemplateSelector : DataTemplateSelector
+    public partial class ArchiveItemTemplateSelector : DataTemplateSelector
     {
         public DataTemplate? DirectoryTemplate { get; set; }
 

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameUI.vcxproj
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameUI.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.props')" />
+  <Import Project="..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.240111.5\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
@@ -205,7 +205,8 @@
     <Import Project="..\..\..\..\packages\boost_regex-vc143.1.84.0\build\boost_regex-vc143.targets" Condition="Exists('..\..\..\..\packages\boost_regex-vc143.1.84.0\build\boost_regex-vc143.targets')" />
     <Import Project="..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
     <Import Project="..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.targets')" />
-    <Import Project="..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.targets')" />
+    <Import Project="..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets')" />
+    <Import Project="..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -218,8 +219,9 @@
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.2428\build\Microsoft.Windows.SDK.BuildTools.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.WindowsAppSDK.1.5.240428000\build\native\Microsoft.WindowsAppSDK.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Web.WebView2.1.0.2739.15\build\native\Microsoft.Web.WebView2.targets'))" />
   </Target>
   <Target Name="AddWildCardItems" AfterTargets="BuildGenerateSources">
     <ItemGroup>

--- a/src/modules/powerrename/PowerRenameUILib/packages.config
+++ b/src/modules/powerrename/PowerRenameUILib/packages.config
@@ -2,8 +2,9 @@
 <packages>
   <package id="boost" version="1.84.0" targetFramework="native" />
   <package id="boost_regex-vc143" version="1.84.0" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.2739.15" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240111.5" targetFramework="native" />
   <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231216.1" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.22621.2428" targetFramework="native" />
-  <package id="Microsoft.WindowsAppSDK" version="1.5.240428000" targetFramework="native" />
+  <package id="Microsoft.WindowsAppSDK" version="1.6.240829007" targetFramework="native" />
 </packages>

--- a/src/modules/previewpane/UnitTests-MarkdownPreviewHandler/UnitTests-MarkdownPreviewHandler.csproj
+++ b/src/modules/previewpane/UnitTests-MarkdownPreviewHandler/UnitTests-MarkdownPreviewHandler.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest" />
+    <PackageReference Include="Microsoft.Web.WebView2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\common\PreviewHandlerCommon.csproj" />

--- a/src/modules/previewpane/UnitTests-SvgPreviewHandler/UnitTests-SvgPreviewHandler.csproj
+++ b/src/modules/previewpane/UnitTests-SvgPreviewHandler/UnitTests-SvgPreviewHandler.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Moq" />
     <PackageReference Include="MSTest" />
+    <PackageReference Include="Microsoft.Web.WebView2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\common\PreviewHandlerCommon.csproj" />

--- a/src/settings-ui/Settings.UI/Converters/AwakeModeToIntConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/AwakeModeToIntConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    public sealed class AwakeModeToIntConverter : IValueConverter
+    public sealed partial class AwakeModeToIntConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/settings-ui/Settings.UI/Converters/ColorFormatConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/ColorFormatConverter.cs
@@ -4,12 +4,11 @@
 
 using System;
 using ManagedCommon;
-using Microsoft.PowerToys.Settings.UI.Library.Helpers;
 using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    public sealed class ColorFormatConverter : IValueConverter
+    public sealed partial class ColorFormatConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/settings-ui/Settings.UI/Converters/ImageResizerFitToIntConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/ImageResizerFitToIntConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters;
 
-public sealed class ImageResizerFitToIntConverter : IValueConverter
+public sealed partial class ImageResizerFitToIntConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/settings-ui/Settings.UI/Converters/ImageResizerFitToStringConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/ImageResizerFitToStringConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    public sealed class ImageResizerFitToStringConverter : IValueConverter
+    public sealed partial class ImageResizerFitToStringConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/settings-ui/Settings.UI/Converters/ImageResizerUnitToIntConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/ImageResizerUnitToIntConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters;
 
-public sealed class ImageResizerUnitToIntConverter : IValueConverter
+public sealed partial class ImageResizerUnitToIntConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/src/settings-ui/Settings.UI/Converters/ImageResizerUnitToStringConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/ImageResizerUnitToStringConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    public sealed class ImageResizerUnitToStringConverter : IValueConverter
+    public sealed partial class ImageResizerUnitToStringConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/settings-ui/Settings.UI/Converters/IndexBitFieldToVisibilityConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/IndexBitFieldToVisibilityConverter.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    public sealed class IndexBitFieldToVisibilityConverter : IValueConverter
+    public sealed partial class IndexBitFieldToVisibilityConverter : IValueConverter
     {
         // Receives a hexadecimal bit mask as a parameter. Will check the value against that bitmask.
         public object Convert(object value, Type targetType, object parameter, string language)

--- a/src/settings-ui/Settings.UI/Converters/KeyVisualTemplateSelector.cs
+++ b/src/settings-ui/Settings.UI/Converters/KeyVisualTemplateSelector.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    internal sealed class KeyVisualTemplateSelector : DataTemplateSelector
+    internal sealed partial class KeyVisualTemplateSelector : DataTemplateSelector
     {
         public DataTemplate KeyVisualTemplate { get; set; }
 

--- a/src/settings-ui/Settings.UI/Converters/ModuleItemTemplateSelector.cs
+++ b/src/settings-ui/Settings.UI/Converters/ModuleItemTemplateSelector.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    public class ModuleItemTemplateSelector : DataTemplateSelector
+    public partial class ModuleItemTemplateSelector : DataTemplateSelector
     {
         public DataTemplate TextTemplate { get; set; }
 

--- a/src/settings-ui/Settings.UI/Converters/RunOptionTemplateSelector.cs
+++ b/src/settings-ui/Settings.UI/Converters/RunOptionTemplateSelector.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    public sealed class RunOptionTemplateSelector : DataTemplateSelector
+    public sealed partial class RunOptionTemplateSelector : DataTemplateSelector
     {
         public DataTemplate CheckBoxTemplate { get; set; }
 

--- a/src/settings-ui/Settings.UI/Converters/StringToInfoBarSeverityConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/StringToInfoBarSeverityConverter.cs
@@ -3,13 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.UI;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    public sealed class StringToInfoBarSeverityConverter : IValueConverter
+    public sealed partial class StringToInfoBarSeverityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/settings-ui/Settings.UI/Converters/UpdateStateToBoolConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/UpdateStateToBoolConverter.cs
@@ -7,7 +7,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    public sealed class UpdateStateToBoolConverter : IValueConverter
+    public sealed partial class UpdateStateToBoolConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/CheckBoxWithDescriptionControl.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/CheckBoxWithDescriptionControl.cs
@@ -9,7 +9,7 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.PowerToys.Settings.UI.Controls
 {
-    public class CheckBoxWithDescriptionControl : CheckBox
+    public partial class CheckBoxWithDescriptionControl : CheckBox
     {
         private CheckBoxWithDescriptionControl _checkBoxSubTextControl;
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/IsEnabledTextBlock/IsEnabledTextBlock.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/IsEnabledTextBlock/IsEnabledTextBlock.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 {
     [TemplateVisualState(Name = "Normal", GroupName = "CommonStates")]
     [TemplateVisualState(Name = "Disabled", GroupName = "CommonStates")]
-    public class IsEnabledTextBlock : Control
+    public partial class IsEnabledTextBlock : Control
     {
         public IsEnabledTextBlock()
         {

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/KeyVisual/KeyVisual.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/KeyVisual/KeyVisual.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
     [TemplateVisualState(Name = "Disabled", GroupName = "CommonStates")]
     [TemplateVisualState(Name = "Default", GroupName = "StateStates")]
     [TemplateVisualState(Name = "Error", GroupName = "StateStates")]
-    public sealed class KeyVisual : Control
+    public sealed partial class KeyVisual : Control
     {
         private const string KeyPresenter = "KeyPresenter";
         private KeyVisual _keyVisual;

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/SettingsGroup/SettingsGroupAutomationPeer.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/SettingsGroup/SettingsGroupAutomationPeer.cs
@@ -6,7 +6,7 @@ using Microsoft.UI.Xaml.Automation.Peers;
 
 namespace Microsoft.PowerToys.Settings.UI.Controls
 {
-    public class SettingsGroupAutomationPeer : FrameworkElementAutomationPeer
+    public partial class SettingsGroupAutomationPeer : FrameworkElementAutomationPeer
     {
         public SettingsGroupAutomationPeer(SettingsGroup owner)
             : base(owner)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Merge in the latest main from PowerToys upstream.

Fixes to make Pal work again with the new version of Windows App SDK:
- Update versions in packages and project files: https://github.com/zadjii-msft/PowerToys/commit/0b0cf459a3a4b7c02f823a14f3a888e9da43099f
- Add WebView 2 package to vcxprojects that include Windows App SDK: https://github.com/zadjii-msft/PowerToys/commit/882205b8ab2889557db97cb3a90464d175baba35
- Add partial to the class definitions that implement WinRT interfaces: https://github.com/zadjii-msft/PowerToys/commit/f96c03de4ad007644241578afc1305fe981ca9fe
- Add reference to WebView 2 for those csprojects that referenced WinAppSDK. The main reason for this is that we want to force the 1.0.2739.15 version we are defining in PowerToys, or else the WindowsAppSDK will try to use WebView 1.0.2651.64 and the binaries in the output path will conflict for the extensions, that would try to bring both 1.0.2739.15 from a C++ dependency 1.0.2651.64 from a C# dependency. https://github.com/zadjii-msft/PowerToys/commit/a1a2677c2d3a8e4cb2e295aedb291527c5871991

Also removes some lines from "src/modules/cmdpal/.vsconfig" which were bothering me to install some VS components that are not needed: https://github.com/zadjii-msft/PowerToys/commit/869fd972db73004aff2cf9842326bdc066efded3
