### PR TITLE
Bring in window size and acrylic

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ActionBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ActionBar.xaml
@@ -8,6 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:viewmodels="using:Microsoft.CmdPal.UI.ViewModels"
+    Background="Transparent"
     mc:Ignorable="d">
 
     <UserControl.Resources>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListDetailPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListDetailPage.xaml
@@ -6,8 +6,8 @@
     xmlns:local="using:Microsoft.CmdPal.UI"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Background="Transparent"
+    mc:Ignorable="d">
 
     <Grid>
         <!-- not using Interactivity:Interaction.Behaviors due to wanting to do AoT -->

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -9,7 +9,7 @@
     xmlns:local="using:Microsoft.CmdPal.UI"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewmodels="using:Microsoft.CmdPal.UI.ViewModels"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    Background="Transparent"
     mc:Ignorable="d">
 
     <Page.Resources>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml
@@ -7,6 +7,7 @@
     xmlns:local="using:Microsoft.CmdPal.UI"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewmodels="using:Microsoft.CmdPal.UI.ViewModels"
+    Closed="MainWindow_Closed"
     mc:Ignorable="d">
 
     <local:ShellPage />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -2,7 +2,13 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.UI.Composition;
+using Microsoft.UI.Composition.SystemBackdrops;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Windows.Graphics;
+using Windows.UI;
+using WinRT;
 
 namespace Microsoft.CmdPal.UI;
 
@@ -11,8 +17,96 @@ namespace Microsoft.CmdPal.UI;
 /// </summary>
 public sealed partial class MainWindow : Window
 {
+    private DesktopAcrylicController? _acrylicController;
+    private SystemBackdropConfiguration? _configurationSource;
+
     public MainWindow()
     {
         InitializeComponent();
+
+        PositionCentered();
+        SetAcrylic();
+    }
+
+    private void PositionCentered()
+    {
+        AppWindow.Resize(new SizeInt32 { Width = 860, Height = 560 });
+        var displayArea = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Nearest);
+        if (displayArea is not null)
+        {
+            var centeredPosition = AppWindow.Position;
+            centeredPosition.X = (displayArea.WorkArea.Width - AppWindow.Size.Width) / 2;
+            centeredPosition.Y = (displayArea.WorkArea.Height - AppWindow.Size.Height) / 2;
+            AppWindow.Move(centeredPosition);
+        }
+    }
+
+    // We want to use DesktopAcrylicKind.Thin and custom colors as this is the default material
+    // other Shell surfaces are using, this cannot be set in XAML however.
+    private void SetAcrylic()
+    {
+        if (DesktopAcrylicController.IsSupported())
+        {
+            // Hooking up the policy object.
+            _configurationSource = new SystemBackdropConfiguration
+            {
+                // Initial configuration state.
+                IsInputActive = true,
+            };
+            UpdateAcrylic();
+        }
+    }
+
+    private void UpdateAcrylic()
+    {
+        _acrylicController = GetAcrylicConfig(Content);
+
+        // Enable the system backdrop.
+        // Note: Be sure to have "using WinRT;" to support the Window.As<...>() call.
+        _acrylicController.AddSystemBackdropTarget(this.As<ICompositionSupportsSystemBackdrop>());
+        _acrylicController.SetSystemBackdropConfiguration(_configurationSource);
+    }
+
+    private static DesktopAcrylicController GetAcrylicConfig(UIElement content)
+    {
+        var feContent = content as FrameworkElement;
+
+        if (feContent?.ActualTheme == ElementTheme.Light)
+        {
+            return new DesktopAcrylicController()
+            {
+                Kind = DesktopAcrylicKind.Thin,
+                TintColor = Color.FromArgb(255, 243, 243, 243),
+                LuminosityOpacity = 0.90f,
+                TintOpacity = 0.0f,
+                FallbackColor = Color.FromArgb(255, 238, 238, 238),
+            };
+        }
+        else
+        {
+            return new DesktopAcrylicController()
+            {
+                Kind = DesktopAcrylicKind.Thin,
+                TintColor = Color.FromArgb(255, 32, 32, 32),
+                LuminosityOpacity = 0.96f,
+                TintOpacity = 0.5f,
+                FallbackColor = Color.FromArgb(255, 28, 28, 28),
+            };
+        }
+    }
+
+    private void DisposeAcrylic()
+    {
+        if (_acrylicController != null)
+        {
+            _acrylicController.Dispose();
+            _acrylicController = null!;
+            _configurationSource = null!;
+        }
+    }
+
+    private void MainWindow_Closed(object sender, WindowEventArgs args)
+    {
+        DisposeAcrylic();
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Microsoft.CmdPal.UI"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    Background="Transparent"
     mc:Ignorable="d">
 
     <Grid>


### PR DESCRIPTION
Brings in default window size/position and acrylic from #60.
Does not respond to theme changes.

![image](https://github.com/user-attachments/assets/c95d2c31-a314-49d1-8067-a4ea6f6e3368)
