### PR TITLE
Create an `IExtensionHost` class, to enable logging

### DIFF
--- a/src/modules/cmdpal/Exts/EverythingExtension/EverythingExtensionCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/EverythingExtension/EverythingExtensionCommandsProvider.cs
@@ -14,9 +14,10 @@ namespace EverythingExtension;
 
 public partial class EverythingExtensionActionsProvider : CommandProvider
 {
-    public string DisplayName => $"Everything extension for cmdpal";
-
-    public IconDataType Icon => new(string.Empty);
+    public EverythingExtensionActionsProvider()
+    {
+        DisplayName = "Everything extension for cmdpal";
+    }
 
     private readonly IListItem[] _commands = [
         new ListItem(new EverythingExtensionPage())
@@ -26,11 +27,7 @@ public partial class EverythingExtensionActionsProvider : CommandProvider
         },
     ];
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return _commands;
     }

--- a/src/modules/cmdpal/Exts/EverythingExtension/EverythingExtensionCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/EverythingExtension/EverythingExtensionCommandsProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace EverythingExtension;
 
-public partial class EverythingExtensionActionsProvider : ICommandProvider
+public partial class EverythingExtensionActionsProvider : CommandProvider
 {
     public string DisplayName => $"Everything extension for cmdpal";
 

--- a/src/modules/cmdpal/Exts/EverythingExtension/Pages/EverythingExtensionPage.cs
+++ b/src/modules/cmdpal/Exts/EverythingExtension/Pages/EverythingExtensionPage.cs
@@ -30,7 +30,7 @@ internal sealed partial class EverythingExtensionPage : DynamicListPage
         Everything_SetMax(20);
     }
 
-    public override ISection[] GetItems(string query)
+    public override IListItem[] GetItems(string query)
     {
         Everything_SetSearchW(query);
 
@@ -60,18 +60,10 @@ internal sealed partial class EverythingExtensionPage : DynamicListPage
                 items.Add(new ListItem(new NoOpCommand() { Name = "(Are you sure Everything is running?)" }));
             }
 
-            return [
-                new ListSection()
-                {
-                    Items = items.ToArray(),
-                }
-            ];
+            return items.ToArray();
         }
 
         var resultCount = Everything_GetNumResults();
-
-        // Create a new ListSections
-        var section = new ListSection();
 
         // Create a List to store ListItems
         var itemList = new List<ListItem>();
@@ -101,9 +93,6 @@ internal sealed partial class EverythingExtensionPage : DynamicListPage
         }
 
         // Convert the List to an array and assign it to the Items property
-        section.Items = itemList.ToArray();
-
-        // Return the ListSection with the items
-        return [section];
+        return itemList.ToArray();
     }
 }

--- a/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsCommandsProvider.cs
@@ -21,8 +21,7 @@ public partial class HackerNewsCommandsProvider : CommandProvider
 
     public override IListItem[] TopLevelCommands()
     {
-        var h = ExtensionHost.Host!.HostingHwnd;
-        _ = h;
+        ExtensionHost.LogMessage(new LogMessage() { Message = "This is a test, from the HackerNews sample" });
 
         return _actions;
     }

--- a/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsCommandsProvider.cs
@@ -8,22 +8,22 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace HackerNewsExtension;
 
-public partial class HackerNewsCommandsProvider : ICommandProvider
+public partial class HackerNewsCommandsProvider : CommandProvider
 {
-    public string DisplayName => $"Hacker News Commands";
-
-    public IconDataType Icon => new(string.Empty);
+    public HackerNewsCommandsProvider()
+    {
+        DisplayName = "Hacker News Commands";
+    }
 
     private readonly IListItem[] _actions = [
         new ListItem(new HackerNewsPage()),
     ];
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
+        var h = ExtensionHost.Host!.HostingHwnd;
+        _ = h;
+
         return _actions;
     }
 }

--- a/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsCommandsProvider.cs
@@ -21,8 +21,6 @@ public partial class HackerNewsCommandsProvider : CommandProvider
 
     public override IListItem[] TopLevelCommands()
     {
-        ExtensionHost.LogMessage(new LogMessage() { Message = "This is a test, from the HackerNews sample" });
-
         return _actions;
     }
 }

--- a/src/modules/cmdpal/Exts/HackerNewsExtension/Properties/launchSettings.json
+++ b/src/modules/cmdpal/Exts/HackerNewsExtension/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "HackerNewsExtension (Package)": {
-      "commandName": "MsixPackage"
+      "commandName": "MsixPackage",
+      "doNotLaunchApp": true
     },
     "HackerNewsExtension (Unpackaged)": {
       "commandName": "Project"

--- a/src/modules/cmdpal/Exts/MastodonExtension/MastodonExtensionPage.cs
+++ b/src/modules/cmdpal/Exts/MastodonExtension/MastodonExtensionPage.cs
@@ -28,19 +28,16 @@ internal sealed partial class MastodonExtensionPage : ListPage
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "This is sample code")]
 public partial class MastodonExtensionActionsProvider : CommandProvider
 {
-    public string DisplayName => $"Mastodon extension for cmdpal Commands";
-
-    public IconDataType Icon => new(string.Empty);
+    public MastodonExtensionActionsProvider()
+    {
+        DisplayName = "Mastodon extension for cmdpal Commands";
+    }
 
     private readonly IListItem[] _actions = [
         new ListItem(new MastodonExtensionPage()),
     ];
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return _actions;
     }

--- a/src/modules/cmdpal/Exts/MastodonExtension/MastodonExtensionPage.cs
+++ b/src/modules/cmdpal/Exts/MastodonExtension/MastodonExtensionPage.cs
@@ -26,7 +26,7 @@ internal sealed partial class MastodonExtensionPage : ListPage
 }
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "This is sample code")]
-public partial class MastodonExtensionActionsProvider : ICommandProvider
+public partial class MastodonExtensionActionsProvider : CommandProvider
 {
     public string DisplayName => $"Mastodon extension for cmdpal Commands";
 

--- a/src/modules/cmdpal/Exts/MediaControlsExtension/MediaActionsProvider.cs
+++ b/src/modules/cmdpal/Exts/MediaControlsExtension/MediaActionsProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions;
 
 namespace MediaControlsExtension;
 
-public partial class MediaActionsProvider : ICommandProvider
+public partial class MediaActionsProvider : CommandProvider
 {
     public string DisplayName => $"Media controls actions";
 

--- a/src/modules/cmdpal/Exts/MediaControlsExtension/MediaActionsProvider.cs
+++ b/src/modules/cmdpal/Exts/MediaControlsExtension/MediaActionsProvider.cs
@@ -4,24 +4,22 @@
 
 using System;
 using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace MediaControlsExtension;
 
 public partial class MediaActionsProvider : CommandProvider
 {
-    public string DisplayName => $"Media controls actions";
-
-    public IconDataType Icon => new(string.Empty);
+    public MediaActionsProvider()
+    {
+        DisplayName = "Media controls actions";
+    }
 
     private readonly IListItem[] _actions = [
         new MediaListItem()
     ];
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return _actions;
     }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarksCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarksCommandProvider.cs
@@ -11,17 +11,15 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-public partial class BookmarksCommandProvider : ICommandProvider
+public partial class BookmarksCommandProvider : CommandProvider
 {
-    public string DisplayName => $"Bookmarks";
-
-    public IconDataType Icon => new(string.Empty);
-
     private readonly List<ICommand> _commands = [];
     private readonly AddBookmarkPage _addNewCommand = new();
 
     public BookmarksCommandProvider()
     {
+        DisplayName = "Bookmarks";
+
         _addNewCommand.AddedAction += AddNewCommand_AddedAction;
     }
 
@@ -30,10 +28,6 @@ public partial class BookmarksCommandProvider : ICommandProvider
         _addNewCommand.AddedAction += AddNewCommand_AddedAction;
         _commands.Clear();
     }
-
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
 
     private void LoadCommands()
     {
@@ -84,7 +78,7 @@ public partial class BookmarksCommandProvider : ICommandProvider
         _commands.AddRange(collected);
     }
 
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         if (_commands.Count == 0)
         {

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
@@ -4,26 +4,20 @@
 
 using System;
 using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Calc;
 
-public partial class CalculatorCommandProvider : ICommandProvider
+public partial class CalculatorCommandProvider : CommandProvider
 {
-    public string DisplayName => $"Calculator";
-
     private readonly CalculatorTopLevelListItem calculatorCommand = new();
 
     public CalculatorCommandProvider()
     {
+        DisplayName = "Calculator";
     }
 
-    public IconDataType Icon => new(string.Empty);
-
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return [calculatorCommand];
     }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.CmdPalSettings/SettingsCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.CmdPalSettings/SettingsCommandProvider.cs
@@ -8,23 +8,16 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Settings;
 
-public partial class SettingsCommandProvider : ICommandProvider
+public partial class SettingsCommandProvider : CommandProvider
 {
-    public string DisplayName => $"Settings";
-
     private readonly SettingsPage settingsPage = new();
 
     public SettingsCommandProvider()
     {
+        DisplayName = $"Settings";
     }
 
-    public IconDataType Icon => new(string.Empty);
-
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return [new ListItem(settingsPage) { Subtitle = "CmdPal settings" }];
     }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Registry/RegistryCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Registry/RegistryCommandsProvider.cs
@@ -8,21 +8,14 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Registry;
 
-public partial class RegistryCommandsProvider : ICommandProvider
+public partial class RegistryCommandsProvider : CommandProvider
 {
-    public string DisplayName => $"Windows Services";
-
     public RegistryCommandsProvider()
     {
+        DisplayName = $"Windows Registry";
     }
 
-    public IconDataType Icon => new(string.Empty);
-
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return [
             new ListItem(new RegistryListPage())

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsServices/WindowsServicesCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsServices/WindowsServicesCommandsProvider.cs
@@ -8,21 +8,14 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.WindowsServices;
 
-public partial class WindowsServicesCommandsProvider : ICommandProvider
+public partial class WindowsServicesCommandsProvider : CommandProvider
 {
-    public string DisplayName => $"Windows Services";
-
     public WindowsServicesCommandsProvider()
     {
+        DisplayName = $"Windows Services";
     }
 
-    public IconDataType Icon => new(string.Empty);
-
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return [
             new ListItem(new ServicesListPage())

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsSettings/WindowsSettingsCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsSettings/WindowsSettingsCommandsProvider.cs
@@ -10,10 +10,8 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.WindowsSettings;
 
-public partial class WindowsSettingsCommandsProvider : ICommandProvider
+public partial class WindowsSettingsCommandsProvider : CommandProvider
 {
-    public string DisplayName => $"Windows Services";
-
     private readonly ListItem _searchSettingsListItem;
 
 #pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
@@ -22,6 +20,8 @@ public partial class WindowsSettingsCommandsProvider : ICommandProvider
 
     public WindowsSettingsCommandsProvider()
     {
+        DisplayName = $"Windows Services";
+
         _windowsSettings = JsonSettingsListHelper.ReadAllPossibleSettings();
         _searchSettingsListItem = new ListItem(new WindowsSettingsListPage(_windowsSettings))
         {
@@ -35,13 +35,7 @@ public partial class WindowsSettingsCommandsProvider : ICommandProvider
         WindowsSettingsPathHelper.GenerateSettingsPathValues(_windowsSettings);
     }
 
-    public IconDataType Icon => new(string.Empty);
-
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return [
             _searchSettingsListItem

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsTerminal/WindowsTerminalCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsTerminal/WindowsTerminalCommandsProvider.cs
@@ -4,26 +4,20 @@
 
 using System;
 using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.WindowsTerminal;
 
-public partial class WindowsTerminalCommandsProvider : ICommandProvider
+public partial class WindowsTerminalCommandsProvider : CommandProvider
 {
-    public string DisplayName => $"Windows Terminal";
-
     private readonly TerminalTopLevelListItem terminalCommand = new();
 
     public WindowsTerminalCommandsProvider()
     {
+        DisplayName = $"Windows Terminal";
     }
 
-    public IconDataType Icon => new(string.Empty);
-
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return [terminalCommand];
     }

--- a/src/modules/cmdpal/Exts/ProcessMonitorExtension/ProcessMonitorCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/ProcessMonitorExtension/ProcessMonitorCommandProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace ProcessMonitorExtension;
 
-internal sealed partial class ProcessMonitorCommandProvider : ICommandProvider
+internal sealed partial class ProcessMonitorCommandProvider : CommandProvider
 {
     public string DisplayName => "Process Monitor Commands";
 

--- a/src/modules/cmdpal/Exts/ProcessMonitorExtension/ProcessMonitorCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/ProcessMonitorExtension/ProcessMonitorCommandProvider.cs
@@ -9,12 +9,9 @@ namespace ProcessMonitorExtension;
 
 internal sealed partial class ProcessMonitorCommandProvider : CommandProvider
 {
-    public string DisplayName => "Process Monitor Commands";
-
-    public IconDataType Icon => new(string.Empty); // Optionally provide an icon URL
-
-    public void Dispose()
+    public ProcessMonitorCommandProvider()
     {
+        DisplayName = "Process Monitor Commands";
     }
 
     private readonly IListItem[] _actions = [
@@ -25,7 +22,7 @@ internal sealed partial class ProcessMonitorCommandProvider : CommandProvider
         },
     ];
 
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return _actions;
     }

--- a/src/modules/cmdpal/Exts/SSHKeychainExtension/SSHKeychainCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/SSHKeychainExtension/SSHKeychainCommandsProvider.cs
@@ -10,9 +10,10 @@ namespace SSHKeychainExtension;
 
 public partial class SSHKeychainCommandsProvider : CommandProvider
 {
-    public string DisplayName => $"SSH Keychain Commands";
-
-    public IconDataType Icon => new(string.Empty);
+    public SSHKeychainCommandsProvider()
+    {
+        DisplayName = "SSH Keychain Commands";
+    }
 
     private readonly IListItem[] _commands = [
        new ListItem(new SSHHostsListPage())
@@ -22,11 +23,7 @@ public partial class SSHKeychainCommandsProvider : CommandProvider
         },
     ];
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return _commands;
     }

--- a/src/modules/cmdpal/Exts/SSHKeychainExtension/SSHKeychainCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/SSHKeychainExtension/SSHKeychainCommandsProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SSHKeychainExtension;
 
-public partial class SSHKeychainCommandsProvider : ICommandProvider
+public partial class SSHKeychainCommandsProvider : CommandProvider
 {
     public string DisplayName => $"SSH Keychain Commands";
 

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/SamplePagesCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/SamplePagesCommandsProvider.cs
@@ -10,9 +10,10 @@ namespace SamplePagesExtension;
 
 public partial class SamplePagesCommandsProvider : CommandProvider
 {
-    public string DisplayName => $"Sample Pages Commands";
-
-    public IconDataType Icon => new(string.Empty);
+    public SamplePagesCommandsProvider()
+    {
+        DisplayName = "Sample Pages Commands";
+    }
 
     private readonly IListItem[] _commands = [
        new ListItem(new SampleMarkdownPage())
@@ -42,11 +43,7 @@ public partial class SamplePagesCommandsProvider : CommandProvider
        }
     ];
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return _commands;
     }

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/SamplePagesCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/SamplePagesCommandsProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SamplePagesExtension;
 
-public partial class SamplePagesCommandsProvider : ICommandProvider
+public partial class SamplePagesCommandsProvider : CommandProvider
 {
     public string DisplayName => $"Sample Pages Commands";
 

--- a/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotCommandsProvider.cs
@@ -11,19 +11,16 @@ namespace SpongebotExtension;
 
 internal sealed partial class SpongebotCommandsProvider : CommandProvider
 {
-    public string DisplayName => $"Spongebob, mocking";
-
-    public IconDataType Icon => new(string.Empty);
+    public SpongebotCommandsProvider()
+    {
+        DisplayName = "Spongebob, mocking";
+    }
 
     private readonly SpongebotPage mainPage = new();
 
     private readonly SpongebotSettingsPage settingsPage = new();
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         var settingsPath = SpongebotPage.StateJsonPath();
         if (!File.Exists(settingsPath))

--- a/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotCommandsProvider.cs
@@ -9,7 +9,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace SpongebotExtension;
 
-internal sealed partial class SpongebotCommandsProvider : ICommandProvider
+internal sealed partial class SpongebotCommandsProvider : CommandProvider
 {
     public string DisplayName => $"Spongebob, mocking";
 

--- a/src/modules/cmdpal/Exts/TemplateExtension/TemplateExtensionCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/TemplateExtension/TemplateExtensionCommandsProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace TemplateExtension;
 
-public partial class TemplateExtensionActionsProvider : ICommandProvider
+public partial class TemplateExtensionActionsProvider : CommandProvider
 {
     public string DisplayName => $"TemplateDisplayName Commands";
 

--- a/src/modules/cmdpal/Exts/TemplateExtension/TemplateExtensionCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/TemplateExtension/TemplateExtensionCommandsProvider.cs
@@ -14,19 +14,16 @@ namespace TemplateExtension;
 
 public partial class TemplateExtensionActionsProvider : CommandProvider
 {
-    public string DisplayName => $"TemplateDisplayName Commands";
-
-    public IconDataType Icon => new(string.Empty);
+    public TemplateExtensionActionsProvider()
+    {
+        DisplayName = "TemplateDisplayName Commands";
+    }
 
     private readonly IListItem[] _commands = [
         new ListItem(new TemplateExtensionPage()),
     ];
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return _commands;
     }

--- a/src/modules/cmdpal/Exts/YouTubeExtension/YouTubeExtensionCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/YouTubeExtension/YouTubeExtensionCommandsProvider.cs
@@ -17,7 +17,7 @@ using YouTubeExtension.Pages;
 
 namespace YouTubeExtension;
 
-public partial class YouTubeExtensionActionsProvider : ICommandProvider
+public partial class YouTubeExtensionActionsProvider : CommandProvider
 {
     public string DisplayName => $"YouTube";
 

--- a/src/modules/cmdpal/Exts/YouTubeExtension/YouTubeExtensionCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/YouTubeExtension/YouTubeExtensionCommandsProvider.cs
@@ -19,9 +19,10 @@ namespace YouTubeExtension;
 
 public partial class YouTubeExtensionActionsProvider : CommandProvider
 {
-    public string DisplayName => $"YouTube";
-
-    public IconDataType Icon => new(string.Empty);
+    public YouTubeExtensionActionsProvider()
+    {
+        DisplayName = "YouTube";
+    }
 
     private readonly IListItem[] _commands = [
         new ListItem(new YouTubeVideosPage())
@@ -48,11 +49,7 @@ public partial class YouTubeExtensionActionsProvider : CommandProvider
 
     private readonly YouTubeAPIPage apiPage = new();
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return TopLevelCommandsAsync().GetAwaiter().GetResult();
     }

--- a/src/modules/cmdpal/WindowsCommandPalette/Builtins/QuitAction/QuitCommandProvider.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Builtins/QuitAction/QuitCommandProvider.cs
@@ -8,21 +8,13 @@ using Windows.Foundation;
 
 namespace WindowsCommandPalette.BuiltinCommands;
 
-public partial class QuitCommandProvider : ICommandProvider
+public partial class QuitCommandProvider : CommandProvider
 {
-    public string DisplayName => string.Empty;
-
-    public IconDataType Icon => new(string.Empty);
-
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
     private readonly QuitAction quitAction = new();
 
     public event TypedEventHandler<object?, object?>? QuitRequested { add => quitAction.QuitRequested += value; remove => quitAction.QuitRequested -= value; }
 
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return [new ListItem(quitAction) { Subtitle = "Exit Command Palette" }];
     }

--- a/src/modules/cmdpal/WindowsCommandPalette/Builtins/ReloadExtensionsCommandProvider.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Builtins/ReloadExtensionsCommandProvider.cs
@@ -8,19 +8,11 @@ using Windows.Foundation;
 
 namespace WindowsCommandPalette.BuiltinCommands;
 
-public partial class ReloadExtensionsCommandProvider : ICommandProvider
+public partial class ReloadExtensionsCommandProvider : CommandProvider
 {
-    public string DisplayName => string.Empty;
-
-    public IconDataType Icon => new(string.Empty);
-
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
     private readonly ReloadExtensionsAction reloadAction = new();
 
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return [new ListItem(reloadAction) { Subtitle = "Reload Command Palette extensions" }];
     }

--- a/src/modules/cmdpal/WindowsCommandPalette/CommandPaletteHost.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/CommandPaletteHost.cs
@@ -3,20 +3,35 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using Microsoft.CmdPal.Common.Services;
 using Microsoft.CmdPal.Extensions;
-using Windows.Win32;
+using Windows.Foundation;
 
 namespace WindowsCommandPalette;
 
 public sealed partial class CommandPaletteHost : IExtensionHost
 {
+    // Static singleton, so that we can access this from anywhere
+    // Post MVVM - this should probably be like, a dependency injection thing.
     public static CommandPaletteHost Instance { get; } = new();
 
     public ulong HostingHwnd => 12345u;
 
-    public string LanguageOverride => throw new NotImplementedException();
+    public string LanguageOverride => string.Empty;
 
-    public void LogMessage(ILogMessage message) => throw new NotImplementedException();
+    public IAsyncAction ShowStatus(IStatusMessage message)
+    {
+        Debug.WriteLine(message.Message);
+        return Task.CompletedTask.AsAsyncAction();
+    }
+
+    public IAsyncAction HideStatus(IStatusMessage message)
+    {
+        return Task.CompletedTask.AsAsyncAction();
+    }
+
+    public IAsyncAction LogMessage(ILogMessage message)
+    {
+        Debug.WriteLine(message.Message);
+        return Task.CompletedTask.AsAsyncAction();
+    }
 }

--- a/src/modules/cmdpal/WindowsCommandPalette/CommandPaletteHost.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/CommandPaletteHost.cs
@@ -14,7 +14,9 @@ public sealed partial class CommandPaletteHost : IExtensionHost
     // Post MVVM - this should probably be like, a dependency injection thing.
     public static CommandPaletteHost Instance { get; } = new();
 
-    public ulong HostingHwnd => 12345u;
+    private ulong _hostHwnd;
+
+    public ulong HostingHwnd => _hostHwnd;
 
     public string LanguageOverride => string.Empty;
 
@@ -33,5 +35,10 @@ public sealed partial class CommandPaletteHost : IExtensionHost
     {
         Debug.WriteLine(message.Message);
         return Task.CompletedTask.AsAsyncAction();
+    }
+
+    public void SetHostHwnd(ulong hostHwnd)
+    {
+        _hostHwnd = hostHwnd;
     }
 }

--- a/src/modules/cmdpal/WindowsCommandPalette/CommandPaletteHost.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/CommandPaletteHost.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.CmdPal.Common.Services;
+using Microsoft.CmdPal.Extensions;
+using Windows.Win32;
+
+namespace WindowsCommandPalette;
+
+public sealed partial class CommandPaletteHost : IExtensionHost
+{
+    public static CommandPaletteHost Instance { get; } = new();
+
+    public ulong HostingHwnd => 12345u;
+
+    public string LanguageOverride => throw new NotImplementedException();
+
+    public void LogMessage(ILogMessage message) => throw new NotImplementedException();
+}

--- a/src/modules/cmdpal/WindowsCommandPalette/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/MainWindow.xaml.cs
@@ -94,6 +94,8 @@ public sealed partial class MainWindow : Window
         SetAcrylic();
         ExtendsContentIntoTitleBar = true;
 
+        CommandPaletteHost.Instance.SetHostHwnd((ulong)hwnd.Value);
+
         // Hide our titlebar. We'll make the sides draggable later
         _appWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
 

--- a/src/modules/cmdpal/WindowsCommandPalette/Views/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Views/CommandProviderWrapper.cs
@@ -39,6 +39,9 @@ public sealed class CommandProviderWrapper
         }
 
         CommandProvider = provider;
+
+        CommandProvider.InitializeWithHost(CommandPaletteHost.Instance);
+
         isValid = true;
     }
 

--- a/src/modules/cmdpal/WindowsCommandPalette/Views/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/WindowsCommandPalette/Views/CommandProviderWrapper.cs
@@ -40,6 +40,7 @@ public sealed class CommandProviderWrapper
 
         CommandProvider = provider;
 
+        // Hook the extension back into us
         CommandProvider.InitializeWithHost(CommandPaletteHost.Instance);
 
         isValid = true;

--- a/src/modules/cmdpal/doc/command-pal-anatomy/command-palette-anatomy.md
+++ b/src/modules/cmdpal/doc/command-pal-anatomy/command-palette-anatomy.md
@@ -178,9 +178,10 @@ In order for users to interact with your extension in the Command Palette, **you
 ```csharp
 public class SSHKeychainCommandsProvider : CommandProvider
 {
-    public string DisplayName => $"SSH Keychain Commands";
-
-    public IconDataType Icon => new(string.Empty);
+    public SSHKeychainCommandsProvider()
+    {
+        DisplayName = "SSH Keychain Commands";
+    }
 
     private readonly IListItem[] _commands = [
        new ListItem(new NoOpCommand())
@@ -190,11 +191,7 @@ public class SSHKeychainCommandsProvider : CommandProvider
         },
     ];
 
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
-    public void Dispose() => throw new NotImplementedException();
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
-
-    public IListItem[] TopLevelCommands()
+    public override IListItem[] TopLevelCommands()
     {
         return _commands;
     }

--- a/src/modules/cmdpal/doc/command-pal-anatomy/command-palette-anatomy.md
+++ b/src/modules/cmdpal/doc/command-pal-anatomy/command-palette-anatomy.md
@@ -176,7 +176,7 @@ At this point you should have your command that you created show up in the root 
 In order for users to interact with your extension in the Command Palette, **you need to provide at least one top level command**. To do this, implement the `ICommandProvider` interface located in the `*CommandsProvider.cs` file created by the extension template. This interface has a single method, `TopLevelCommands()`, that returns a list of commands that will be displayed in the root view of the Command Palette. Remember, each top level command that a user sees is represented by a [ListItem](#listitem). In other words, the `TopLevelCommands()` method will return a list of `ListItems`, where each `ListItem` represents a command that will be displayed in the [root view](#root-view) of the Command Palette.
 
 ```csharp
-public class SSHKeychainCommandsProvider : ICommandProvider
+public class SSHKeychainCommandsProvider : CommandProvider
 {
     public string DisplayName => $"SSH Keychain Commands";
 

--- a/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
+++ b/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
@@ -1,7 +1,7 @@
 ---
 author: Mike Griese
 created on: 2024-07-19
-last updated: 2024-10-22
+last updated: 2024-11-04
 issue id: n/a
 ---
 
@@ -62,6 +62,7 @@ functionality.
       - [`INotifyPropChanged`](#inotifypropchanged)
       - [`ICommandProvider`](#icommandprovider)
     - [Settings](#settings)
+    - [Retrieving info from the host](#retrieving-info-from-the-host)
   - [Helper SDK Classes](#helper-sdk-classes)
     - [Default implementations](#default-implementations)
     - [Using the Clipboard](#using-the-clipboard)
@@ -869,7 +870,7 @@ public class SpongebotPage : Microsoft.Windows.Run.Extensions.MarkdownPage, IFal
         return t.Result;
     }
 }
-internal sealed class SpongebotCommandsProvider : ICommandProvider
+internal sealed class SpongebotCommandsProvider : CommandProvider
 {
     public IListItem[] TopLevelCommands()
     {
@@ -1125,6 +1126,8 @@ interface ICommandProvider requires Windows.Foundation.IClosable
     // TODO! IFormPage SettingsPage { get; };
 
     IListItem[] TopLevelCommands();
+
+    void InitializeWithHost(IExtensionHost host);
 };
 ```
 
@@ -1149,6 +1152,36 @@ Cards is great for real-time saving of settings though.
 We probably also want to provide a helper class for storing settings, so that
 apps don't need to worry too much about mucking around with that. I'm especially
 thinking about storing credentials securely.
+
+### Retrieving info from the host
+
+TODO! write me
+
+```c#
+enum LogState
+{
+    Info = 0,
+    InProgress,
+    Success,
+    Warning,
+    Error,
+};
+
+interface ILogMessage
+{
+    LogState State { get; };
+    String Message { get; };
+    // TODO! Icon maybe? Work with design on this
+};
+
+interface IExtensionHost
+{
+    UInt64 HostingHwnd { get; };
+    String LanguageOverride { get; };
+
+    void LogMessage(ILogMessage message);
+};
+```
 
 ## Helper SDK Classes
 

--- a/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
+++ b/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
@@ -1157,32 +1157,6 @@ thinking about storing credentials securely.
 
 TODO! write me
 
-```c#
-enum LogState
-{
-    Info = 0,
-    InProgress,
-    Success,
-    Warning,
-    Error,
-};
-
-interface ILogMessage
-{
-    LogState State { get; };
-    String Message { get; };
-    // TODO! Icon maybe? Work with design on this
-};
-
-interface IExtensionHost
-{
-    UInt64 HostingHwnd { get; };
-    String LanguageOverride { get; };
-
-    void LogMessage(ILogMessage message);
-};
-```
-
 ## Helper SDK Classes
 
 As a part of the `Microsoft.CmdPal.Extensions` namespace, we'll provide a set of
@@ -1274,35 +1248,88 @@ in their extensions.
 
 ### Status messages
 
-[TODO!]: write this
-
-[TODO!]: I'm removing the bit about status updates for now. This is tricky, because things like `InvokableCommand`s want to be able to set status messages too, and they won't necessarily be able to communicate back up to the page hosting them.
-Actions should be able to display realtime feedback to the user:
-
 <img src="./grid-actions-mock.png" height="300px" /> <img src="./grid-status-loading-mock.png" height="300px" /> <img src="./grid-status-success-mock.png" height="300px" />
 
-* PushStatus(StatusMessage) - this will push a status message to the UI. This
-  will be shown in the status bar at the bottom of the window. The status bar
-  will show the most recent status message.
-* PopStatus() - this will begin to fade out the active status message. If there
-  are no more status messages, the status bar will disappear.
+Extensions will want to be able to communicate feedback to the user, based on
+what's going on inside the extension. 
 
-```cs
-runtimeclass PageStatus {
-    bool IsIndeterminate { get; };
-    double ProgressPercent { get; };
-    PageStatusKind Kind { get; };
-    String Caption { get; };
-}
-enum PageStatusKind {
-    Info,
+Consider a `winget` extension that allows the user to search for and install
+packages. When the user starts an install, the extension should be able to show
+a progress bar for the install, and then show a success or error message to the
+user, depending on the result.
+
+To do so, extensions can make use of the `IExtensionHost` interface. This is an
+object which extensions shouldn't implement themselves. Rather, this is
+implemented by the host app itself. On this class is the `ShowStatus` &
+`HideStatus` methods.
+
+Calling `ShowStatus` will display a given message to the user in the status area
+of the UI. The extension can provide an info/success/warning/error state to
+colorize the message. The extension can also provide progress info in the
+message.
+
+When the extension wants to hide the message, they can call `HideStatus`,
+passing the same message object to the method. The host app will keep a log of
+all status's written to it, so a user can alway view old messages once they've
+been hidden. The message also conforms to `INotifyPropChanged`, so extensions
+can modify an existing message if they'd like to. This is recommended, rather
+than writing lots of individual updates as separate messages.
+
+```c#
+enum MessageState
+{
+    Info = 0,
     Success,
     Warning,
-    Error
-}
+    Error,
+};
+
+interface IProgressState requires INotifyPropChanged
+{
+    Boolean IsIndeterminate { get; };
+    UInt32 ProgressPercent { get; };
+};
+
+interface IStatusMessage requires INotifyPropChanged
+{
+    MessageState State { get; };
+    IProgressState Progress { get; };
+    String Message { get; };
+    // TODO! Icon maybe? Work with design on this
+};
+
+interface ILogMessage
+{
+    MessageState State { get; };
+    String Message { get; };
+};
+
+interface IExtensionHost
+{
+    UInt64 HostingHwnd { get; };
+    String LanguageOverride { get; };
+
+    Windows.Foundation.IAsyncAction ShowStatus(IStatusMessage message);
+    Windows.Foundation.IAsyncAction HideStatus(IStatusMessage message);
+
+    Windows.Foundation.IAsyncAction LogMessage(ILogMessage message);
+};
 ```
 
-push pop sounds wrong. Maybe `AddStatus` and `ClearStatus`?
+There's also a `LogMessage` method provided by the `IExtensionHost` interface.
+This is useful for apps that want to write to the debug log of the host app
+itself. These are for messages that wouldn't otherwise be visible to the user,
+but may be helpful for debugging purposes.
+
+`IExtensionHost` is implemented by the hosting app itself. It is passed to a
+command provider on startup, when the host app first connects to the extension.
+For apps which use the helpers library, this will be managed for them. Consumers
+of the helpers lib can simply call `Helpers.ExtensionHost.Host` to get the
+instance from the host app.
+
+[TODO!]: I'm marking these methods async right now, to force extension authors
+to remember that these are x-proc calls, and should be treated asynchronously.
+Should the other properties be async too?
 
 ## Class diagram
 

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/CommandProvider.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/CommandProvider.cs
@@ -1,0 +1,24 @@
+namespace Microsoft.CmdPal.Extensions.Helpers;
+
+public partial class CommandProvider : ICommandProvider
+{
+    private string _displayName = string.Empty;
+
+    private IconDataType _icon = new(string.Empty);
+
+    public string DisplayName { get => _displayName; protected set => _displayName = value; }
+
+    public IconDataType Icon { get => _icon; protected set => _icon = value; }
+
+    public virtual IListItem[] TopLevelCommands() => throw new NotImplementedException();
+
+    public void InitializeWithHost(IExtensionHost host)
+    {
+        ExtensionHost.Initialize(host);
+    }
+
+#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
+    public void Dispose() => throw new NotImplementedException();
+#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
+
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ExtensionHost.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ExtensionHost.cs
@@ -1,0 +1,13 @@
+namespace Microsoft.CmdPal.Extensions.Helpers;
+
+public class ExtensionHost
+{
+    private static IExtensionHost? _host;
+
+    public static IExtensionHost? Host => _host;
+
+    public static void Initialize(IExtensionHost host)
+    {
+        _host = host;
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ExtensionHost.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ExtensionHost.cs
@@ -10,4 +10,21 @@ public class ExtensionHost
     {
         _host = host;
     }
+
+    public static void LogMessage(ILogMessage message)
+    {
+        // TODO this feels like bad async
+        if (Host != null)
+        {
+            // really just fire-and-forget
+            new Task(async () => 
+            {
+                try
+                {
+                    await Host.LogMessage(message);
+                }
+                catch (Exception) { }
+            }).Start();
+        }
+    }
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ProgressState.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ProgressState.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.Extensions.Helpers;
+
+public partial class ProgressState : BaseObservable, IProgressState
+{
+    private bool _isIndeterminate;
+    
+    private uint _progressPercent;
+
+    public bool IsIndeterminate
+    {
+        get => _isIndeterminate;
+        set
+        {
+            _isIndeterminate = value;
+            OnPropertyChanged(nameof(IsIndeterminate));
+        }
+    }
+
+    public uint ProgressPercent
+    {
+        get => _progressPercent;
+        set
+        {
+            _progressPercent = value;
+            OnPropertyChanged(nameof(ProgressPercent));
+        }
+    }
+}
+
+public partial class StatusMessage : BaseObservable, IStatusMessage
+{
+    private MessageState _messageState = MessageState.Info;
+
+    private string _message = string.Empty;
+
+    private IProgressState? _progressState;
+
+    public string Message
+    {
+        get => _message;
+        set
+        {
+            _message = value;
+            OnPropertyChanged(nameof(Message));
+        }
+    }
+    
+    public MessageState State
+    {
+        get => _messageState;
+        set
+        {
+            _messageState = value;
+            OnPropertyChanged(nameof(State));
+        }
+    }
+
+    public IProgressState? Progress
+    {
+        get => _progressState;
+        set
+        {
+            _progressState = value;
+            OnPropertyChanged(nameof(Progress));
+        }
+    }
+}
+
+public partial class LogMessage : BaseObservable, ILogMessage
+{
+    private MessageState _messageState = MessageState.Info;
+
+    private string _message = string.Empty;
+
+    public string Message
+    {
+        get => _message;
+        set
+        {
+            _message = value;
+            OnPropertyChanged(nameof(Message));
+        }
+    }
+    
+    public MessageState State
+    {
+        get => _messageState;
+        set
+        {
+            _messageState = value;
+            OnPropertyChanged(nameof(State));
+        }
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
@@ -122,6 +122,32 @@ namespace Microsoft.CmdPal.Extensions
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
     interface IDetailsSeparator requires IDetailsData {}
     
+    enum LogState
+    {
+        Info = 0,
+        InProgress,
+        Success,
+        Warning,
+        Error,
+    };
+    
+    [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
+    interface ILogMessage
+    {
+        LogState State { get; };
+        String Message { get; };
+        // TODO! Icon maybe? Work with design on this
+    };
+    
+    [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
+    interface IExtensionHost
+    {
+        UInt64 HostingHwnd { get; };
+        String LanguageOverride { get; };
+    
+        void LogMessage(ILogMessage message);
+    };
+    
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
     interface IPage requires ICommand {
         String Title { get; };
@@ -212,6 +238,8 @@ namespace Microsoft.CmdPal.Extensions
         // TODO! IFormPage SettingsPage { get; };
     
         IListItem[] TopLevelCommands();
+    
+        void InitializeWithHost(IExtensionHost host);
     };
     
 

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
@@ -122,21 +122,35 @@ namespace Microsoft.CmdPal.Extensions
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
     interface IDetailsSeparator requires IDetailsData {}
     
-    enum LogState
+    enum MessageState
     {
         Info = 0,
-        InProgress,
         Success,
         Warning,
         Error,
     };
     
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
-    interface ILogMessage
+    interface IProgressState requires INotifyPropChanged
     {
-        LogState State { get; };
+        Boolean IsIndeterminate { get; };
+        UInt32 ProgressPercent { get; };
+    };
+    
+    [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
+    interface IStatusMessage requires INotifyPropChanged
+    {
+        MessageState State { get; };
+        IProgressState Progress { get; };
         String Message { get; };
         // TODO! Icon maybe? Work with design on this
+    };
+    
+    [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
+    interface ILogMessage
+    {
+        MessageState State { get; };
+        String Message { get; };
     };
     
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
@@ -145,7 +159,10 @@ namespace Microsoft.CmdPal.Extensions
         UInt64 HostingHwnd { get; };
         String LanguageOverride { get; };
     
-        void LogMessage(ILogMessage message);
+        Windows.Foundation.IAsyncAction ShowStatus(IStatusMessage message);
+        Windows.Foundation.IAsyncAction HideStatus(IStatusMessage message);
+    
+        Windows.Foundation.IAsyncAction LogMessage(ILogMessage message);
     };
     
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]


### PR DESCRIPTION
Allow extensions to send status messages to the host app.

As an example, you can now:

```cs
ExtensionHost.LogMessage(new LogMessage() { Message = "This is a test, from the HackerNews sample" });
```

And have that appear in the host apps debug console. 

Closes #134 
Closes #118 

Should also make resolving #87 and #135 easier. 

We don't have the design of these status messages totally planned out yet. But this should at least make it possible. For those in the back, **this does not actually display these messages anywhere in the host UX currently**. 

-----

Other information that's currently included:
* The host app's HWND. Way too many times does the Windows API need an HWND, which extensions won't have, but the host app does. 
* The `LanguageOverride`. This is in case we ever want to support `PrimaryLanguageOverride` in the host app. 

