### PR TITLE
Trivial: Tidy up some of the samples

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Registry/Pages/RegistryListPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Registry/Pages/RegistryListPage.cs
@@ -3,21 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net.Http;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft.CmdPal.Ext.Registry.Classes;
 using Microsoft.CmdPal.Ext.Registry.Helpers;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
-using Microsoft.UI.Windowing;
 
 namespace Microsoft.CmdPal.Ext.Registry;
 
@@ -27,7 +18,7 @@ internal sealed partial class RegistryListPage : DynamicListPage
 
     public RegistryListPage()
     {
-        Icon = new(string.Empty);
+        Icon = new("\uE74C"); // OEM
         Name = "Windows Registry";
         _defaultIconPath = "Images/reg.light.png";
     }
@@ -54,12 +45,9 @@ internal sealed partial class RegistryListPage : DynamicListPage
 
             // when only one sub-key was found and a user search for values ("\\")
             // show the filtered list of values of one sub-key
-            if (searchForValueName && list.Count == 1)
-            {
-                return ResultHelper.GetValuesFromKey(list.First().Key, _defaultIconPath, queryValueName);
-            }
-
-            return ResultHelper.GetResultList(list, _defaultIconPath);
+            return searchForValueName && list.Count == 1
+                ? ResultHelper.GetValuesFromKey(list.First().Key, _defaultIconPath, queryValueName)
+                : ResultHelper.GetResultList(list, _defaultIconPath);
         }
         else if (baseKeyList.Count() > 1)
         {

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Registry/RegistryCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Registry/RegistryCommandsProvider.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
 
@@ -20,8 +19,8 @@ public partial class RegistryCommandsProvider : CommandProvider
         return [
             new ListItem(new RegistryListPage())
             {
-                Title = "Search the Windows Registry",
-                Subtitle = "Navigates inside the Windows registry",
+                Title = "Registry",
+                Subtitle = "Navigate the Windows registry",
             }
         ];
     }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsServices/WindowsServicesCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsServices/WindowsServicesCommandsProvider.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
 
@@ -20,8 +19,8 @@ public partial class WindowsServicesCommandsProvider : CommandProvider
         return [
             new ListItem(new ServicesListPage())
             {
-                Title = "Search Windows Services",
-                Subtitle = "Quickly manage all Windows Services",
+                Title = "Windows Services",
+                Subtitle = "Manage Windows Services",
             }
         ];
     }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsSettings/Pages/WindowsSettingsListPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsSettings/Pages/WindowsSettingsListPage.cs
@@ -3,21 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net.Http;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft.CmdPal.Ext.WindowsSettings.Classes;
-using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
-using Microsoft.UI.Windowing;
 
 namespace Microsoft.CmdPal.Ext.WindowsSettings;
 
@@ -28,7 +18,7 @@ internal sealed partial class WindowsSettingsListPage : DynamicListPage
 
     public WindowsSettingsListPage(Classes.WindowsSettings windowsSettings)
     {
-        Icon = new(string.Empty);
+        Icon = new("\uE713"); // Settings
         Name = "Windows Settings";
         _defaultIconPath = "Images/WindowsSettings.light.png";
         _windowsSettings = windowsSettings;
@@ -92,12 +82,7 @@ internal sealed partial class WindowsSettingsListPage : DynamicListPage
             }
 
             // Search by key char '>' for app name and settings path
-            if (query.Contains('>'))
-            {
-                return ResultHelper.FilterBySettingsPath(found, query);
-            }
-
-            return false;
+            return query.Contains('>') ? ResultHelper.FilterBySettingsPath(found, query) : false;
         }
     }
 
@@ -108,7 +93,7 @@ internal sealed partial class WindowsSettingsListPage : DynamicListPage
 
     public override IListItem[] GetItems()
     {
-        ListItem[] items = Query(SearchText).ToArray();
+        var items = Query(SearchText).ToArray();
 
         return items;
     }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsSettings/WindowsSettingsCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsSettings/WindowsSettingsCommandsProvider.cs
@@ -2,8 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using Microsoft.CmdPal.Ext.WindowsSettings.Classes;
 using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
@@ -20,13 +18,13 @@ public partial class WindowsSettingsCommandsProvider : CommandProvider
 
     public WindowsSettingsCommandsProvider()
     {
-        DisplayName = $"Windows Services";
+        DisplayName = $"Windows Settings";
 
         _windowsSettings = JsonSettingsListHelper.ReadAllPossibleSettings();
         _searchSettingsListItem = new ListItem(new WindowsSettingsListPage(_windowsSettings))
         {
-            Title = "Search Windows Settings",
-            Subtitle = "Quickly navigate to specific Windows settings",
+            Title = "Windows Settings",
+            Subtitle = "Navigate to specific Windows settings",
         };
 
         UnsupportedSettingsHelper.FilterByBuild(_windowsSettings);

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPage.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPage.cs
@@ -2,19 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
-using Microsoft.UI.Windowing;
 
 namespace SamplePagesExtension;
 

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleMarkdownPage.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleMarkdownPage.cs
@@ -2,19 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Xml.Linq;
-using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
-using Microsoft.UI.Windowing;
 
 namespace SamplePagesExtension;
 
@@ -25,17 +13,152 @@ internal sealed partial class SampleMarkdownPage : MarkdownPage
 
 Markdown is a lightweight markup language with plain text formatting syntax. It's often used to format readme files, for writing messages in online forums, and to create rich text using a simple, plain text editor.
 
----
+## Basic Markdown Formatting
 
-## Headings
+### Headings
 
-You can create headings using the `#` symbol, with the number of `#` determining the heading level.
+    # This is an <h1> tag
+    ## This is an <h2> tag
+    ### This is an <h3> tag
+    #### This is an <h4> tag
+    ##### This is an <h5> tag
+    ###### This is an <h6> tag
+    
+### Emphasis
+
+    *This text will be italic*
+    _This will also be italic_
+    
+    **This text will be bold**
+    __This will also be bold__
+    
+    _You **can** combine them_
+    
+Result:
+
+*This text will be italic*
+
+_This will also be italic_
+
+**This text will be bold**
+
+__This will also be bold__
+
+_You **can** combine them_
+
+### Lists
+
+**Inordered:**
+
+    * Milk
+    * Bread
+        * Wholegrain
+    * Butter
+
+Result:
+
+* Milk
+* Bread
+    * Wholegrain
+* Butter
+
+**Ordered:**
+
+    1. Tidy the kitchen  
+    2. Prepare ingredients  
+    3. Cook delicious things
+
+Result:
+
+1. Tidy the kitchen  
+2. Prepare ingredients  
+3. Cook delicious things
+
+### Images
+
+    ![Alt Text](url)
+
+Result:
+
+![paintin'](https://i.imgur.com/93XJSNh.png)
+
+### Links
+
+    [link](http://example.com)
+    
+Result:
+
+[link](http://example.com)
+
+### Blockquotes
+
+    As Albert Einstein said:
+
+    > If we knew what it was we were doing,
+    > it would not be called research, would it?
+
+Result:
+
+As Albert Einstein said:
+
+> If we knew what it was we were doing,
+> it would not be called research, would it?
+
+### Horizontal Rules
 
 ```markdown
-# H1 Heading
-## H2 Heading
-### H3 Heading
-#### H4 Heading
+    ---
+```
+
+Result:
+
+---
+
+### Code Snippets
+
+    Indenting by 4 spaces will turn an entire paragraph into a code-block.
+
+Result:
+
+    .my-link {
+        text-decoration: underline;
+    }
+
+### Reference Lists & Titles
+
+    **The quick brown [fox][1], jumped over the lazy [dog][2].**
+
+    [1]: https://en.wikipedia.org/wiki/Fox ""Wikipedia: Fox""
+    [2]: https://en.wikipedia.org/wiki/Dog ""Wikipedia: Dog""
+
+Result:
+
+**The quick brown [fox][1], jumped over the lazy [dog][2].**
+
+[1]: https://en.wikipedia.org/wiki/Fox ""Wikipedia: Fox""
+[2]: https://en.wikipedia.org/wiki/Dog ""Wikipedia: Dog""
+
+### Escaping
+
+    \*literally\*
+
+Result:
+
+\*literally\*
+
+## Advanced Markdown
+
+Note: Some syntax which is not standard to native Markdown. They're extensions of the language.
+
+### Strike-throughs
+
+    ~~deleted words~~
+
+Result:
+
+~~deleted words~~
+
+
 ";
 
     public SampleMarkdownPage()

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/SamplePagesCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/SamplePagesCommandsProvider.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
 
@@ -16,36 +15,11 @@ public partial class SamplePagesCommandsProvider : CommandProvider
     }
 
     private readonly IListItem[] _commands = [
-       new ListItem(new SampleMarkdownPage())
+       new ListItem(new SamplesListPage())
        {
-           Title = "Markdown Page Sample Command",
-           Subtitle = "SamplePages Extension",
+           Title = "Sample Pages",
+           Subtitle = "View example commands",
        },
-       new ListItem(new SampleListPage())
-       {
-           Title = "List Page Sample Command",
-           Subtitle = "SamplePages Extension",
-       },
-       new ListItem(new SampleFormPage())
-       {
-           Title = "Form Page Sample Command",
-           Subtitle = "SamplePages Extension",
-       },
-       new ListItem(new SampleListPageWithDetails())
-       {
-           Title = "List Page With Details Sample Command",
-           Subtitle = "SamplePages Extension",
-       },
-       new ListItem(new SampleDynamicListPage())
-       {
-           Title = "Dynamic List Page Command",
-           Subtitle = "SamplePages Extension",
-       },
-       new ListItem(new SampleSettingsPage())
-       {
-           Title = "Sample settings page",
-           Subtitle = "A demo of the settings helpers",
-       }
     ];
 
     public override IListItem[] TopLevelCommands()

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/SamplesListPage.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/SamplesListPage.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
+
+namespace SamplePagesExtension;
+
+public partial class SamplesListPage : ListPage
+{
+    private readonly IListItem[] _commands = [
+       new ListItem(new SampleMarkdownPage())
+       {
+           Title = "Markdown Page Sample Command",
+           Subtitle = "Display a page of rendered markdown",
+       },
+       new ListItem(new SampleListPage())
+       {
+           Title = "List Page Sample Command",
+           Subtitle = "Display a list of items",
+       },
+       new ListItem(new SampleFormPage())
+       {
+           Title = "Form Page Sample Command",
+           Subtitle = "Define inputs to retrieve input from the user",
+       },
+       new ListItem(new SampleListPageWithDetails())
+       {
+           Title = "List Page With Details Sample Command",
+           Subtitle = "A list of items, each with additional details to display",
+       },
+       new ListItem(new SampleDynamicListPage())
+       {
+           Title = "Dynamic List Page Command",
+           Subtitle = "Changes the list of items in response to the typed query",
+       },
+       new ListItem(new SampleSettingsPage())
+       {
+           Title = "Sample settings page",
+           Subtitle = "A demo of the settings helpers",
+       }
+    ];
+
+    public SamplesListPage()
+    {
+        Name = "Samples";
+        Icon = new("\ue946"); // Info
+    }
+
+    public override IListItem[] GetItems()
+    {
+        return _commands;
+    }
+}

--- a/src/modules/cmdpal/Exts/YouTubeExtension/Pages/YouTubeChannelsPage.cs
+++ b/src/modules/cmdpal/Exts/YouTubeExtension/Pages/YouTubeChannelsPage.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -38,7 +37,7 @@ internal sealed partial class YouTubeChannelsPage : DynamicListPage
     private async Task<IListItem[]> DoGetItems(string query)
     {
         // Fetch YouTube channels based on the query
-        List<YouTubeChannel> items = await GetYouTubeChannels(query);
+        var items = await GetYouTubeChannels(query);
 
         // Create a section and populate it with the channel results
         var section = items.Select(channel => new ListItem(new OpenChannelLinkAction(channel.ChannelUrl))
@@ -70,7 +69,7 @@ internal sealed partial class YouTubeChannelsPage : DynamicListPage
 
         var channels = new List<YouTubeChannel>();
 
-        using (HttpClient client = new HttpClient())
+        using (var client = new HttpClient())
         {
             try
             {
@@ -113,7 +112,7 @@ internal sealed partial class YouTubeChannelsPage : DynamicListPage
     // Fetch subscriber count for each channel using a separate API call
     private static async Task<long> GetChannelSubscriberCount(string apiKey, string channelId)
     {
-        using HttpClient client = new HttpClient();
+        using var client = new HttpClient();
         {
             try
             {

--- a/src/modules/cmdpal/WindowsCommandPalette/Views/MarkdownPage.xaml
+++ b/src/modules/cmdpal/WindowsCommandPalette/Views/MarkdownPage.xaml
@@ -97,7 +97,7 @@
                 x:Name="mdTextBox"
                 Background="Transparent"
                 IsTextSelectionEnabled="True"
-                Text="{x:Bind ViewModel.MarkdownContent, Mode=OneWay}" />
+                Text="" />
         </ScrollViewer>
 
         <!--  Footer  -->


### PR DESCRIPTION
* I put the sample pages into a single top-level command, so deploying that extension didn't add 5 top-level commands to your palette
* I tightened up some of the phrasing for the samples, and the builtins, to be less repetitive
* I added a few icons
* I made the markdown sample longer (and work more reliably)
* and also thank you Hawker for auto-format on save, you the man

(targets #142)