### PR TITLE
Hide the titlebar, again

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml
@@ -10,5 +10,6 @@
     Closed="MainWindow_Closed"
     mc:Ignorable="d">
 
-    <local:ShellPage />
+    <local:ShellPage x:Name="RootShellPage"
+                     Margin="0, 24, 0, 0" />
 </Window>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml
@@ -11,5 +11,5 @@
     mc:Ignorable="d">
 
     <local:ShellPage x:Name="RootShellPage"
-                     Margin="0, 24, 0, 0" />
+                     Margin="0, 12, 0, 0" />
 </Window>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -4,10 +4,13 @@
 
 using Microsoft.UI.Composition;
 using Microsoft.UI.Composition.SystemBackdrops;
+using Microsoft.UI.Input;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Windows.Foundation;
 using Windows.Graphics;
 using Windows.UI;
+using Windows.UI.WindowManagement;
 using WinRT;
 
 namespace Microsoft.CmdPal.UI;
@@ -26,6 +29,20 @@ public sealed partial class MainWindow : Window
 
         PositionCentered();
         SetAcrylic();
+
+        // Hide our titlebar.
+        // We need to both ExtendsContentIntoTitleBar, then set the height to Collapsed
+        // to hide the old caption buttons. Then, in UpdateRegionsForCustomTitleBar,
+        // we'll make the top drag-able again.
+        ExtendsContentIntoTitleBar = true;
+        AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
+        SizeChanged += WindowSizeChanged;
+        UpdateRegionsForCustomTitleBar();
+    }
+
+    private void WindowSizeChanged(object sender, WindowSizeChangedEventArgs args)
+    {
+        UpdateRegionsForCustomTitleBar();
     }
 
     private void PositionCentered()
@@ -71,20 +88,16 @@ public sealed partial class MainWindow : Window
     {
         var feContent = content as FrameworkElement;
 
-        if (feContent?.ActualTheme == ElementTheme.Light)
-        {
-            return new DesktopAcrylicController()
+        return feContent?.ActualTheme == ElementTheme.Light
+            ? new DesktopAcrylicController()
             {
                 Kind = DesktopAcrylicKind.Thin,
                 TintColor = Color.FromArgb(255, 243, 243, 243),
                 LuminosityOpacity = 0.90f,
                 TintOpacity = 0.0f,
                 FallbackColor = Color.FromArgb(255, 238, 238, 238),
-            };
-        }
-        else
-        {
-            return new DesktopAcrylicController()
+            }
+            : new DesktopAcrylicController()
             {
                 Kind = DesktopAcrylicKind.Thin,
                 TintColor = Color.FromArgb(255, 32, 32, 32),
@@ -92,7 +105,6 @@ public sealed partial class MainWindow : Window
                 TintOpacity = 0.5f,
                 FallbackColor = Color.FromArgb(255, 28, 28, 28),
             };
-        }
     }
 
     private void DisposeAcrylic()
@@ -108,5 +120,50 @@ public sealed partial class MainWindow : Window
     private void MainWindow_Closed(object sender, WindowEventArgs args)
     {
         DisposeAcrylic();
+    }
+
+    // Updates our window s.t. the top of the window is dragable.
+    private void UpdateRegionsForCustomTitleBar()
+    {
+        // Specify the interactive regions of the title bar.
+        var scaleAdjustment = RootShellPage.XamlRoot.RasterizationScale;
+
+        // Get the rectangle around our XAML content. We're going to mark this
+        // rectangle as "Passthrough", so that the normal window operations
+        // (resizing, dragging) don't apply in this space.
+        var transform = RootShellPage.TransformToVisual(null);
+
+        // Reserve 24px of space at the top for dragging.
+        var bounds = transform.TransformBounds(new Rect(
+            0,
+            24,
+            RootShellPage.ActualWidth,
+            RootShellPage.ActualHeight));
+        var contentRect = GetRect(bounds, scaleAdjustment);
+        var rectArray = new RectInt32[] { contentRect };
+        var nonClientInputSrc =
+            InputNonClientPointerSource.GetForWindowId(this.AppWindow.Id);
+        nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, rectArray);
+
+        // Add four drag-able regions, around the sides of our content
+        var w = RootShellPage.ActualWidth;
+        var h = RootShellPage.ActualHeight;
+        var dragSides = new RectInt32[]
+        {
+            GetRect(new Rect(0, 0, w, 24), scaleAdjustment), // the top, 24 tall
+            GetRect(new Rect(0, h - 24, RootShellPage.ActualWidth, 24), scaleAdjustment), // the bottom
+            GetRect(new Rect(0, 0, 24, h), scaleAdjustment), // the left, 24xh
+            GetRect(new Rect(w - 24, 0, 24, h), scaleAdjustment), // the right
+        };
+        nonClientInputSrc.SetRegionRects(NonClientRegionKind.Caption, dragSides);
+    }
+
+    private static RectInt32 GetRect(Rect bounds, double scale)
+    {
+        return new RectInt32(
+            _X: (int)Math.Round(bounds.X * scale),
+            _Y: (int)Math.Round(bounds.Y * scale),
+            _Width: (int)Math.Round(bounds.Width * scale),
+            _Height: (int)Math.Round(bounds.Height * scale));
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -33,10 +33,16 @@ public sealed partial class MainWindow : Window
         // Hide our titlebar.
         // We need to both ExtendsContentIntoTitleBar, then set the height to Collapsed
         // to hide the old caption buttons. Then, in UpdateRegionsForCustomTitleBar,
-        // we'll make the top drag-able again.
+        // we'll make the top drag-able again. (after our content loads)
         ExtendsContentIntoTitleBar = true;
         AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
         SizeChanged += WindowSizeChanged;
+        RootShellPage.Loaded += RootShellPage_Loaded;
+    }
+
+    private void RootShellPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        // Now that our content has loaded, we can update our dragable regions
         UpdateRegionsForCustomTitleBar();
     }
 
@@ -141,19 +147,15 @@ public sealed partial class MainWindow : Window
             RootShellPage.ActualHeight));
         var contentRect = GetRect(bounds, scaleAdjustment);
         var rectArray = new RectInt32[] { contentRect };
-        var nonClientInputSrc =
-            InputNonClientPointerSource.GetForWindowId(this.AppWindow.Id);
+        var nonClientInputSrc = InputNonClientPointerSource.GetForWindowId(this.AppWindow.Id);
         nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, rectArray);
 
-        // Add four drag-able regions, around the sides of our content
+        // Add a drag-able region on top
         var w = RootShellPage.ActualWidth;
-        var h = RootShellPage.ActualHeight;
+        _ = RootShellPage.ActualHeight;
         var dragSides = new RectInt32[]
         {
             GetRect(new Rect(0, 0, w, 24), scaleAdjustment), // the top, 24 tall
-            GetRect(new Rect(0, h - 24, RootShellPage.ActualWidth, 24), scaleAdjustment), // the bottom
-            GetRect(new Rect(0, 0, 24, h), scaleAdjustment), // the left, 24xh
-            GetRect(new Rect(w - 24, 0, 24, h), scaleAdjustment), // the right
         };
         nonClientInputSrc.SetRegionRects(NonClientRegionKind.Caption, dragSides);
     }


### PR DESCRIPTION
Does the `ExtendsContentIntoTitleBar` thing to hide the titlebar.

Also re-adds the logic that resizes our drag rect, so that the window is movable again. 