### PR TITLE
Some various minor clean-up

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="AdaptiveCards.Templating" Version="2.0.2" />
     <PackageVersion Include="Appium.WebDriver" Version="4.4.5" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="1.0.0-beta.12" />
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0-preview2" />
     <PackageVersion Include="CommunityToolkit.WinUI.Animations" Version="8.2.241112-preview1" />
     <PackageVersion Include="CommunityToolkit.WinUI.Collections" Version="8.2.241112-preview1" />
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.241112-preview1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,14 +9,14 @@
     <PackageVersion Include="Appium.WebDriver" Version="4.4.5" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="1.0.0-beta.12" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageVersion Include="CommunityToolkit.WinUI.Animations" Version="8.0.240109" />
-    <PackageVersion Include="CommunityToolkit.WinUI.Collections" Version="8.0.240109" />
-    <PackageVersion Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.0.240109" />
-    <PackageVersion Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.0.240109" />
-    <PackageVersion Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.0.240109" />
-    <PackageVersion Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.0.240109" />
-    <PackageVersion Include="CommunityToolkit.WinUI.Converters" Version="8.0.240109" />
-    <PackageVersion Include="CommunityToolkit.WinUI.Extensions" Version="8.0.240109" />
+    <PackageVersion Include="CommunityToolkit.WinUI.Animations" Version="8.2.241112-preview1" />
+    <PackageVersion Include="CommunityToolkit.WinUI.Collections" Version="8.2.241112-preview1" />
+    <PackageVersion Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.241112-preview1" />
+    <PackageVersion Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.241112-preview1" />
+    <PackageVersion Include="CommunityToolkit.WinUI.Controls.Segmented" Version="8.2.241112-preview1" />
+    <PackageVersion Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.241112-preview1" />
+    <PackageVersion Include="CommunityToolkit.WinUI.Converters" Version="8.2.241112-preview1" />
+    <PackageVersion Include="CommunityToolkit.WinUI.Extensions" Version="8.2.241112-preview1" />
     <PackageVersion Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
     <PackageVersion Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
     <PackageVersion Include="ControlzEx" Version="6.0.0" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviders/QuitAction.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviders/QuitAction.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+
+namespace Microsoft.CmdPal.UI.ViewModels.BuiltinCommands;
+
+public partial class QuitAction : InvokableCommand, IFallbackHandler
+{
+    public QuitAction()
+    {
+        Icon = new("\uE711");
+    }
+
+    public override ICommandResult Invoke()
+    {
+        WeakReferenceMessenger.Default.Send<QuitMessage>();
+        return CommandResult.KeepOpen();
+    }
+
+    public void UpdateQuery(string query)
+    {
+        if (query.StartsWith('q'))
+        {
+            Name = "Quit";
+        }
+        else
+        {
+            Name = string.Empty;
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviders/QuitCommandProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviders/QuitCommandProvider.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+
+namespace Microsoft.CmdPal.UI.ViewModels.BuiltinCommands;
+
+/// <summary>
+/// Built-in Provider for a top-level command which can quit the application. Invokes the <see cref="QuitAction"/>, which sends a <see cref="QuitMessage"/>.
+/// </summary>
+public partial class QuitCommandProvider : CommandProvider
+{
+    private readonly QuitAction quitAction = new();
+
+    public override ICommandItem[] TopLevelCommands()
+    {
+        return [];
+    }
+
+    public override IFallbackCommandItem[] FallbackCommands()
+    {
+        return [new FallbackCommandItem(quitAction) { Subtitle = "Exit Command Palette" }];
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviders/ReloadExtensionsAction.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviders/ReloadExtensionsAction.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
+
+namespace Microsoft.CmdPal.UI.ViewModels.BuiltinCommands;
+
+public partial class ReloadExtensionsAction : InvokableCommand, IFallbackHandler
+{
+    public ReloadExtensionsAction()
+    {
+        Icon = new("\uE72C"); // Refresh icon
+    }
+
+    public override ICommandResult Invoke()
+    {
+        return CommandResult.GoHome();
+    }
+
+    public void UpdateQuery(string query)
+    {
+        if (query.StartsWith('r'))
+        {
+            Name = "Reload";
+        }
+        else
+        {
+            Name = string.Empty;
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviders/ReloadExtensionsCommandProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviders/ReloadExtensionsCommandProvider.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
+
+namespace Microsoft.CmdPal.UI.ViewModels.BuiltinCommands;
+
+/// <summary>
+/// Built-in Provider for a top-level command which can reload extensions. Invokes the <see cref="ReloadExtensionsAction"/>.
+/// </summary>
+public partial class ReloadExtensionsCommandProvider : CommandProvider
+{
+    private readonly ReloadExtensionsAction reloadAction = new();
+
+    public override ICommandItem[] TopLevelCommands()
+    {
+        return [];
+    }
+
+    public override IFallbackCommandItem[] FallbackCommands()
+    {
+        return [new FallbackCommandItem(reloadAction) { Subtitle = "Reload Command Palette extensions" }];
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/QuitMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/QuitMessage.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.ViewModels.BuiltinCommands;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Messages;
+
+/// <summary>
+/// Message which closes the application. Used by <see cref="QuitAction"/> via <see cref="QuitCommandProvider"/>.
+/// </summary>
+public record QuitMessage()
+{
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Microsoft.CmdPal.UI.ViewModels.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Microsoft.CmdPal.UI.ViewModels.csproj
@@ -6,6 +6,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal</OutputPath>
+	<!-- Disable SA1313 for Primary Constructor fields conflict https://learn.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/instance-constructors#primary-constructors  -->
+	<NoWarn>SA1313;</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Microsoft.CmdPal.UI.ViewModels.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Microsoft.CmdPal.UI.ViewModels.csproj
@@ -6,6 +6,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal</OutputPath>
+	<!-- For MVVM Toolkit Partial Properties/AOT support -->
+	<LangVersion>preview</LangVersion>
 	<!-- Disable SA1313 for Primary Constructor fields conflict https://learn.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/instance-constructors#primary-constructors  -->
 	<NoWarn>SA1313;</NoWarn>
   </PropertyGroup>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ViewModels/ActionBarContextItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ViewModels/ActionBarContextItemViewModel.cs
@@ -11,12 +11,12 @@ public partial class ActionBarContextItemViewModel : ObservableObject
     ////private ICommand _command;
 
     [ObservableProperty]
-    private string _name = "Placeholder"; // Command.Name;
+    public partial string Name { get; set; } = "Placeholder";
 
     ////private IconDataType Icon => Command.Icon;
 
     [ObservableProperty]
-    private bool _canInvoke = true; // Command != null && Command is IInvokableCommand or IPage;
+    public partial bool CanInvoke { get; set; } = true;
 
     // TODO: do we want the icon here or get it over in the UI project?
     ////[ObservableProperty]

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ViewModels/ActionBarViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ViewModels/ActionBarViewModel.cs
@@ -10,13 +10,13 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public partial class ActionBarViewModel : ObservableObject
 {
     [ObservableProperty]
-    private string _actionName = string.Empty;
+    public partial string ActionName { get; set; } = string.Empty;
 
     [ObservableProperty]
-    private bool _moreCommandsAvailable = false;
+    public partial bool MoreCommandsAvailable { get; set; } = false;
 
     [ObservableProperty]
-    private ObservableCollection<ActionBarContextItemViewModel> _contextActions = [];
+    public partial ObservableCollection<ActionBarContextItemViewModel> ContextActions { get; set; } = [];
 
     public ActionBarViewModel()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ViewModels/ListViewModel.cs
@@ -16,7 +16,7 @@ public partial class ListViewModel : ObservableObject
     // Observable from MVVM Toolkit will auto create public properties that use INotifyPropertyChange change
     // https://learn.microsoft.com/dotnet/communitytoolkit/mvvm/observablegroupedcollections for grouping support
     [ObservableProperty]
-    private ObservableGroupedCollection<string, ListItemViewModel> _items = [];
+    public partial ObservableGroupedCollection<string, ListItemViewModel> Items { get; set; } = [];
 
     public ListViewModel(IListPage model)
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ViewModels/ShellViewModel.cs
@@ -11,10 +11,11 @@ using Microsoft.CmdPal.Extensions.Helpers;
 using Microsoft.CmdPal.Models;
 using Microsoft.CmdPal.UI.Pages;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public partial class ShellViewModel : ObservableObject
+public partial class ShellViewModel(IServiceProvider _serviceProvider) : ObservableObject
 {
     [ObservableProperty]
     private bool _isLoaded = false;
@@ -23,16 +24,13 @@ public partial class ShellViewModel : ObservableObject
 
     public ObservableCollection<ExtensionObject<IListItem>> TopLevelCommands { get; set; } = [];
 
-    private readonly IEnumerable<ICommandProvider> _builtInCommands;
-
-    public ShellViewModel(IEnumerable<ICommandProvider> builtInCommands)
-    {
-        _builtInCommands = builtInCommands;
-    }
+    private IEnumerable<ICommandProvider>? _builtInCommands;
 
     [RelayCommand]
     public async Task<bool> LoadAsync()
     {
+        _builtInCommands = _serviceProvider.GetServices<ICommandProvider>();
+
         // Load Built In Commands First
         foreach (var provider in _builtInCommands)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ViewModels/ShellViewModel.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public partial class ShellViewModel(IServiceProvider _serviceProvider) : ObservableObject
 {
     [ObservableProperty]
-    private bool _isLoaded = false;
+    public partial bool IsLoaded { get; set; } = false;
 
     public ObservableCollection<CommandProviderWrapper> ActionsProvider { get; set; } = [];
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -11,6 +11,7 @@ using Microsoft.CmdPal.Ext.WindowsSettings;
 using Microsoft.CmdPal.Ext.WindowsTerminal;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.CmdPal.UI.ViewModels.BuiltinCommands;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 
@@ -66,12 +67,11 @@ public partial class App : Application
         ServiceCollection services = new();
 
         // Built-in Commands
-        // NOTE: Quit and Reload are still missing from this list.
         services.AddSingleton<ICommandProvider, BookmarksCommandProvider>();
         services.AddSingleton<ICommandProvider, CalculatorCommandProvider>();
         services.AddSingleton<ICommandProvider, SettingsCommandProvider>();
-        ////BuiltInCommands.Add(_quitCommandProvider);
-        ////BuiltInCommands.Add(_reloadCommandProvider);
+        services.AddSingleton<ICommandProvider, QuitCommandProvider>();
+        services.AddSingleton<ICommandProvider, ReloadExtensionsCommandProvider>();
         services.AddSingleton<ICommandProvider, WindowsTerminalCommandsProvider>();
         services.AddSingleton<ICommandProvider, WindowsServicesCommandsProvider>();
         services.AddSingleton<ICommandProvider, RegistryCommandsProvider>();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -62,6 +62,7 @@ public partial class App : Application
     /// </summary>
     private static ServiceProvider ConfigureServices()
     {
+        // TODO: It's in the Labs feed, but we can use Sergio's AOT-friendly source generator for this: https://github.com/CommunityToolkit/Labs-Windows/discussions/463
         ServiceCollection services = new();
 
         // Built-in Commands
@@ -69,13 +70,15 @@ public partial class App : Application
         services.AddSingleton<ICommandProvider, BookmarksCommandProvider>();
         services.AddSingleton<ICommandProvider, CalculatorCommandProvider>();
         services.AddSingleton<ICommandProvider, SettingsCommandProvider>();
+        ////BuiltInCommands.Add(_quitCommandProvider);
+        ////BuiltInCommands.Add(_reloadCommandProvider);
         services.AddSingleton<ICommandProvider, WindowsTerminalCommandsProvider>();
         services.AddSingleton<ICommandProvider, WindowsServicesCommandsProvider>();
         services.AddSingleton<ICommandProvider, RegistryCommandsProvider>();
         services.AddSingleton<ICommandProvider, WindowsSettingsCommandsProvider>();
 
         // ViewModels
-        services.AddSingleton<ShellViewModel>((services) => new(services.GetServices<ICommandProvider>()));
+        services.AddSingleton<ShellViewModel>();
 
         return services.BuildServiceProvider();
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -23,7 +23,8 @@ public sealed partial class ListPage : Page,
     {
         this.InitializeComponent();
 
-        WeakReferenceMessenger.Default.RegisterAll(this);
+        WeakReferenceMessenger.Default.Register<NavigateNextCommand>(this);
+        WeakReferenceMessenger.Default.Register<NavigatePreviousCommand>(this);
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
@@ -15,7 +17,8 @@ namespace Microsoft.CmdPal.UI;
 /// <summary>
 /// An empty window that can be used on its own or navigated to within a Frame.
 /// </summary>
-public sealed partial class MainWindow : Window
+public sealed partial class MainWindow : Window,
+    IRecipient<QuitMessage>
 {
     private DesktopAcrylicController? _acrylicController;
     private SystemBackdropConfiguration? _configurationSource;
@@ -26,6 +29,8 @@ public sealed partial class MainWindow : Window
 
         PositionCentered();
         SetAcrylic();
+
+        WeakReferenceMessenger.Default.Register<QuitMessage>(this);
     }
 
     private void PositionCentered()
@@ -103,6 +108,11 @@ public sealed partial class MainWindow : Window
             _acrylicController = null!;
             _configurationSource = null!;
         }
+    }
+
+    public void Receive(QuitMessage message)
+    {
+        Close();
     }
 
     private void MainWindow_Closed(object sender, WindowEventArgs args)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
@@ -31,7 +31,9 @@ public sealed partial class ShellPage :
         this.InitializeComponent();
 
         // how we are doing navigation around
-        WeakReferenceMessenger.Default.RegisterAll(this);
+        WeakReferenceMessenger.Default.Register<NavigateBackMessage>(this);
+        WeakReferenceMessenger.Default.Register<NavigateToDetailsMessage>(this);
+        WeakReferenceMessenger.Default.Register<NavigateToListMessage>(this);
 
         RootFrame.Navigate(typeof(LoadingPage), ViewModel);
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- 17a3088ea581ec0826ffa212103fe3099d085c32 Switches non-AOT safe RegisterAll call to Register with type for Messenger pattern
- fa962a574db0bcf168f322127bc3fbae8c649e7a Use Dependency Injection for Constructor of ShellViewModel to start this pattern going (as we covered in the MVVM crash course mtg)
- 0bdd21a837352bba13901a7fc58ff28f89551147 Re-add Quit/Reload and use Messenger, but they won't appear in UI yet as Fallback Commands and we don't have search
- dd1b1289cb4ccf4a1dece59f5ed4bb206c5ee39a Setup initial debounce strategy for search in UI layer, though search still not implemented (think found a WCT bug too, will investigate)
- 98041ea11043732fa449c7a99d9e64d43597fcaf Update to latest WCT packages to help us test before our release 😅

