### PR TITLE
I think this fixes our winmd pains, but at what cost

### DIFF
--- a/src/modules/cmdpal/check-extensions.ps1
+++ b/src/modules/cmdpal/check-extensions.ps1
@@ -5,6 +5,7 @@ Write-output "Checking repo root at $gitroot"
 $extensionsRoot = "$gitroot\x64\Debug\WinUI3Apps\CmdPalExtensions"
 Get-ChildItem -Path $extensionsRoot | ForEach-Object {
     $extensionName = $_.Name
+    Write-Host "`e[1m$extensionName`e[m"
     $extensionName
     $extensionAppx = $_.PsPath + "\Appx"
     if ((Test-Path $extensionAppx) -eq $false) {
@@ -23,11 +24,39 @@ Get-ChildItem -Path $extensionsRoot | ForEach-Object {
         }
     }
 }
-$winmdRoot = "$gitroot\\x64\Debug\Microsoft.CmdPal.Extensions"
-$winmdOutput = "$winmdRoot\Microsoft.CmdPal.Extensions.winmd"
-if ((Test-Path $appxWinmd)) {
-    Write-Host "Found Microsoft.CmdPal.Extensions.winmd where it's supposed to be"
+
+Write-Host "`e[1mChecking host apps:`e[m"
+$hostAppxRoot = "$gitroot/x64/Debug/WinUI3Apps/CmdPal"
+$hostAppxWinmd = $hostAppxRoot + "/Microsoft.CmdPal.Extensions.winmd"
+$prototypeAppxRoot = "$gitroot/x64/Debug/WinUI3Apps/CmdPal.Poc"
+$prototypeAppxWinmd = $hostAppxRoot + "/Microsoft.CmdPal.Extensions.winmd"
+if ((Test-Path $hostAppxWinmd)) {
+    Write-Host "  Found Microsoft.CmdPal.Extensions.winmd in The Real App's Appx/"
+}
+else {
+    Write-Host "  `e[31;1mUNEXPECTED`e[0m: Did not find Microsoft.CmdPal.Extensions.winmd in The Real App's Appx/"    
+    Write-Host "    Go look in: "    
+    Write-Host "    start file://$hostAppxRoot"    
+}
+if ((Test-Path $prototypeAppxWinmd)) {
+    Write-Host "  Found Microsoft.CmdPal.Extensions.winmd in the prototype's Appx/"
+}
+else {
+    Write-Host "  `e[31;1mUNEXPECTED`e[0m: Did not find Microsoft.CmdPal.Extensions.winmd in the prototype's Appx/"    
+    Write-Host "    Go look in: "    
+    Write-Host "    start file://$prototypeAppxRoot"    
+}
+
+Write-Host "`e[1mChecking actual extension interface project output:`e[m"
+
+$winmdRoot = "$gitroot/x64/Debug/Microsoft.CmdPal.Extensions"
+$winmdOutput = "$winmdRoot/Microsoft.CmdPal.Extensions.winmd"
+
+if ((Test-Path $winmdOutput)) {
+    Write-Host "  Found Microsoft.CmdPal.Extensions.winmd where it's built"
 }
 else {
     Write-Host "  `e[31;1mUNEXPECTED`e[0m: Did not find Microsoft.CmdPal.Extensions.winmd where it's supposed to be built! Did you build Microsoft.CmdPal.Extensions?"    
+    Write-Host "  Go look in: "    
+    Write-Host "  start file://$winmdRoot"    
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Microsoft.CmdPal.Extensions.Helpers.csproj
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Microsoft.CmdPal.Extensions.Helpers.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\..\Common.Dotnet.CsWinRT.props" />
+
   <PropertyGroup>
-    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal</OutputPath>
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\Microsoft.CmdPal.Extensions.Helpers</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -33,4 +34,7 @@
     <ProjectReference Include="..\Microsoft.CmdPal.Extensions\Microsoft.CmdPal.Extensions.vcxproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="$(TargetDir)\..\Microsoft.CmdPal.Extensions\Microsoft.CmdPal.Extensions.winmd" Link="Microsoft.CmdPal.Extensions.winmd" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
1. Manually copy `Microsoft.CmdPal.Extensions.winmd` into our helper library's output directory. If we do that, then it rolls up to the packages that reference it. 
   * This only started failing for me on 17.13. Before that (I think on 17.11) this just worked automatically?
   * This feels bodgy
2. Update the helper script to be more informative

Refs #104. I don't want to say that it fixes it till we never see it again, but I think this fixes it.

I did not test this on 17.11. I'll need to find a machine that has it to make sure I don't explode the world
