### PR TITLE
Silence nativeDebugging spew

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Properties/launchSettings.json
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "Microsoft.CmdPal.UI (Package)": {
-      "commandName": "MsixPackage",
-      "nativeDebugging": true
+      "commandName": "MsixPackage"
     },
     "Microsoft.CmdPal.UI (Unpackaged)": {
       "commandName": "Project"


### PR DESCRIPTION
I got the extensions loading in TRA, but literally every WinRT call I made resulted in spew like:
 
 
```
Exception thrown at 0x00007FFE9422FA4C (KernelBase.dll) in Microsoft.CmdPal.UI.exe: WinRT originate error - 0x80040155 : 'Failed to find proxy registration for IID: {377D30E5-0D97-577F-A0F1-2E916A03B4E1}.'.
'Microsoft.CmdPal.UI.exe' (Win32): Loaded 'D:\dev\public\powertoys\x64\Debug\WinUI3Apps\CmdPal\AppX\Microsoft.CmdPal.Extensions.winmd'. Module was built without symbols.
Exception thrown at 0x00007FFE9422FA4C (KernelBase.dll) in Microsoft.CmdPal.UI.exe: 0x40080202: WinRT transform error (parameters: 0x0000000080040155, 0x0000000080004002, 0x000000000000001D, 0x000000341FA7E750).
```
 
(Some `RoOriginate`s and WinRT transform exceptions). NOTABLY, these got logged to VS's debug output, but the app would power on through - slowly, albeit, because every method call was logging to debug out. But it worked, and worked great without the debugger. AND this wasn't happening in the POC app. What gives?
 
Turns out, I had this line in `Microsoft.CmdPal.UI\Properties\launchSettings.json`:
 
```json
"nativeDebugging": true
```

Take that out, and presto - no debug spew. 
 