### PR TITLE
Add the All Apps page to the MVVM app.

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsCommandProvider.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
+
+namespace Microsoft.CmdPal.Ext.Apps.Programs;
+
+public partial class AllAppsCommandProvider : CommandProvider
+{
+    private readonly AllAppsPage _page = new();
+
+    private readonly CommandItem _listItem;
+
+    public AllAppsCommandProvider()
+    {
+        DisplayName = "All Apps";
+        _listItem = new(_page) { Subtitle = "Search installed apps" };
+    }
+
+    public override ICommandItem[] TopLevelCommands()
+    {
+        return [_listItem];
+    }
+}

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
@@ -75,7 +75,7 @@ public sealed partial class AllAppsPage : ListPage
                     Name = app.Name,
                     Subtitle = app.Description,
                     IcoPath = app.FullPath, // similarly, this should be IcoPath, but :shrug:
-                    ExePath = app.FullPath,
+                    ExePath = app.LnkFilePath ?? app.FullPath,
                     DirPath = app.Location,
                 });
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/OpenPathAction.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/OpenPathAction.cs
@@ -23,7 +23,7 @@ internal sealed partial class OpenPathAction(string target) : InvokableCommand
 
     public override CommandResult Invoke()
     {
-        LaunchTarget(_target).Start();
+        _ = LaunchTarget(_target).ConfigureAwait(false);
 
         return CommandResult.GoHome();
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CmdPal.Common.Services;
+using Microsoft.CmdPal.Ext.Apps.Programs;
 using Microsoft.CmdPal.Ext.Bookmarks;
 using Microsoft.CmdPal.Ext.Calc;
 using Microsoft.CmdPal.Ext.Registry;
@@ -72,6 +73,7 @@ public partial class App : Application
         services.AddSingleton(TaskScheduler.FromCurrentSynchronizationContext());
 
         // Built-in Commands
+        services.AddSingleton<ICommandProvider, AllAppsCommandProvider>();
         services.AddSingleton<ICommandProvider, BookmarksCommandProvider>();
         services.AddSingleton<ICommandProvider, CalculatorCommandProvider>();
         services.AddSingleton<ICommandProvider, SettingsCommandProvider>();


### PR DESCRIPTION
Pretty straightforward. This never got ported, because it didn't have a CommandProvider. Now it does.