### PR TITLE
Add support for the Details pane again

### DIFF
--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPageWithDetails.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPageWithDetails.cs
@@ -2,19 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
-using Microsoft.UI.Windowing;
 
 namespace SamplePagesExtension;
 
@@ -32,11 +21,11 @@ internal sealed partial class SampleListPageWithDetails : ListPage
         return [
             new ListItem(new NoOpCommand())
             {
-                Title = "TODO: Implement your extension here",
+                Title = "This page demonstrates Details on ListItems",
                 Details = new Details()
                 {
                     Title = "List Item 1",
-                    Body = "### Example of markdown details",
+                    Body = "Each of these items can have a `Body` formatted with **Markdown**",
                 },
             },
             new ListItem(new NoOpCommand())
@@ -46,22 +35,34 @@ internal sealed partial class SampleListPageWithDetails : ListPage
                 Details = new Details()
                 {
                     Title = "List Item 2",
-                    Body = "### Example of markdown details",
+                    Body = SampleMarkdownPage.SampleMarkdownText,
                 },
             },
             new ListItem(new NoOpCommand())
             {
                 Title = "This one has a tag too",
                 Subtitle = "the one with a tag",
-                Tags = [new Tag()
-                {
-                    Text = "Sample Tag",
-                }
-                        ],
+                Tags = [
+                    new Tag()
+                    {
+                        Text = "Sample Tag",
+                    }
+                ],
                 Details = new Details()
                 {
                     Title = "List Item 3",
                     Body = "### Example of markdown details",
+                },
+            },
+            new ListItem(new NoOpCommand())
+            {
+                Title = "This one has a hero image",
+                Tags = [],
+                Details = new Details()
+                {
+                    Title = "Hero Image Example",
+                    HeroImage = new("https://m.media-amazon.com/images/M/MV5BNDBkMzVmNGQtYTM2OC00OWRjLTk5OWMtNzNkMDI4NjFjNTZmXkEyXkFqcGdeQXZ3ZXNsZXk@._V1_QL75_UX500_CR0,0,500,281_.jpg"),
+                    Body = "It is literally an image of a hero",
                 },
             }
         ];

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleMarkdownPage.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleMarkdownPage.cs
@@ -8,7 +8,7 @@ namespace SamplePagesExtension;
 
 internal sealed partial class SampleMarkdownPage : MarkdownPage
 {
-    private readonly string _markdown = @"
+    public static readonly string SampleMarkdownText = @"
 # Markdown Guide
 
 Markdown is a lightweight markup language with plain text formatting syntax. It's often used to format readme files, for writing messages in online forums, and to create rich text using a simple, plain text editor.
@@ -167,8 +167,5 @@ Result:
         Name = "Sample Markdown Page";
     }
 
-    public override string[] Bodies()
-    {
-        return [_markdown];
-    }
+    public override string[] Bodies() => [SampleMarkdownText];
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsPaneViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsPaneViewModel.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class DetailsPaneViewModel : ObservableObject
+{
+    public DetailsViewModel? Details { get; set; }
+
+    public DetailsPaneViewModel()
+    {
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsPaneViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsPaneViewModel.cs
@@ -8,7 +8,8 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 
 public partial class DetailsPaneViewModel : ObservableObject
 {
-    public DetailsViewModel? Details { get; set; }
+    [ObservableProperty]
+    public partial DetailsViewModel? Details { get; set; }
 
     public DetailsPaneViewModel()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class DetailsViewModel(IDetails _details, TaskScheduler Scheduler) : ExtensionObjectViewModel
+{
+    private readonly ExtensionObject<IDetails> _detailsModel = new(_details);
+
+    // Remember - "observable" properties from the model (via PropChanged)
+    // cannot be marked [ObservableProperty]
+
+    // TODO: Icon
+    // TODO: Metadata is an array of IDetailsElement,
+    // where IDetailsElement = {IDetailsTags, IDetailsLink, IDetailsSeparator}
+    public string Title { get; private set; } = string.Empty;
+
+    public string Body { get; private set; } = string.Empty;
+
+    public override void InitializeProperties()
+    {
+        var model = _detailsModel.Unsafe;
+        if (model == null)
+        {
+            return;
+        }
+
+        Title = model.Title;
+        Body = model.Body;
+
+        UpdateProperty(nameof(Title));
+        UpdateProperty(nameof(Body));
+    }
+
+    protected void UpdateProperty(string propertyName) => Task.Factory.StartNew(() => { OnPropertyChanged(propertyName); }, CancellationToken.None, TaskCreationOptions.None, Scheduler);
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
@@ -22,6 +22,10 @@ public partial class ListItemViewModel(IListItem model, TaskScheduler scheduler)
 
     public string Section { get; private set; } = string.Empty;
 
+    public DetailsViewModel? Details { get; private set; }
+
+    public bool HasDetails => Details != null;
+
     public override void InitializeProperties()
     {
         base.InitializeProperties();
@@ -41,6 +45,13 @@ public partial class ListItemViewModel(IListItem model, TaskScheduler scheduler)
             .ToList() ?? [];
         TextToSuggest = li.TextToSuggest;
         Section = li.Section ?? string.Empty;
+        var extensionDetails = li.Details;
+        if (extensionDetails != null)
+        {
+            Details = new(extensionDetails, Scheduler);
+            UpdateProperty(nameof(Details));
+            UpdateProperty(nameof(HasDetails));
+        }
 
         UpdateProperty(nameof(HasTags));
         UpdateProperty(nameof(Tags));
@@ -75,6 +86,12 @@ public partial class ListItemViewModel(IListItem model, TaskScheduler scheduler)
                 break;
             case nameof(Section):
                 this.Section = model.Section ?? string.Empty;
+                break;
+            case nameof(Details):
+                var extensionDetails = model.Details;
+                Details = extensionDetails != null ? new(extensionDetails, Scheduler) : null;
+                UpdateProperty(nameof(Details));
+                UpdateProperty(nameof(HasDetails));
                 break;
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
@@ -49,6 +49,7 @@ public partial class ListItemViewModel(IListItem model, TaskScheduler scheduler)
         if (extensionDetails != null)
         {
             Details = new(extensionDetails, Scheduler);
+            Details.InitializeProperties();
             UpdateProperty(nameof(Details));
             UpdateProperty(nameof(HasDetails));
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -72,7 +72,19 @@ public partial class ListViewModel : PageViewModel
     private void InvokeItem(ListItemViewModel item) => WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(item.Command));
 
     [RelayCommand]
-    private void UpdateSelectedItem(ListItemViewModel item) => WeakReferenceMessenger.Default.Send<UpdateActionBarMessage>(new(item));
+    private void UpdateSelectedItem(ListItemViewModel item)
+    {
+        WeakReferenceMessenger.Default.Send<UpdateActionBarMessage>(new(item));
+
+        if (ShowDetails && item.HasDetails)
+        {
+            WeakReferenceMessenger.Default.Send<ShowDetailsMessage>(new(item.Details!));
+        }
+        else
+        {
+            WeakReferenceMessenger.Default.Send<HideDetailsMessage>(new());
+        }
+    }
 
     public override void InitializeProperties()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -21,6 +21,12 @@ public partial class ListViewModel : PageViewModel
 
     private readonly ExtensionObject<IListPage> _model;
 
+    // Remember - "observable" properties from the model (via PropChanged)
+    // cannot be marked [ObservableProperty]
+    public bool ShowDetails { get; private set; }
+
+    public string PlaceholderText { get => string.IsNullOrEmpty(field) ? "Type here to search..." : field; private set; } = string.Empty;
+
     public ListViewModel(IListPage model, TaskScheduler scheduler)
         : base(model, scheduler)
     {
@@ -78,7 +84,35 @@ public partial class ListViewModel : PageViewModel
             return; // throw?
         }
 
+        ShowDetails = listPage.ShowDetails;
+        UpdateProperty(nameof(ShowDetails));
+        PlaceholderText = listPage.PlaceholderText;
+        UpdateProperty(nameof(PlaceholderText));
+
         FetchItems();
         listPage.ItemsChanged += Model_ItemsChanged;
+    }
+
+    protected override void FetchProperty(string propertyName)
+    {
+        base.FetchProperty(propertyName);
+
+        var model = this._model.Unsafe;
+        if (model == null)
+        {
+            return; // throw?
+        }
+
+        switch (propertyName)
+        {
+            case nameof(ShowDetails):
+                this.ShowDetails = model.ShowDetails;
+                break;
+            case nameof(PlaceholderText):
+                this.PlaceholderText = model.PlaceholderText;
+                break;
+        }
+
+        UpdateProperty(propertyName);
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/HideDetailsMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/HideDetailsMessage.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Messages;
+
+public record HideDetailsMessage()
+{
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/ShowDetailsMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/ShowDetailsMessage.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Messages;
+
+public record ShowDetailsMessage(DetailsViewModel Details)
+{
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/DetailsPane.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/DetailsPane.xaml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="Microsoft.CmdPal.UI.Controls.DetailsPane"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:Microsoft.CmdPal.UI.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    xmlns:viewmodels="using:Microsoft.CmdPal.UI.ViewModels"
+    Background="Transparent"
+    mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <converters:StringVisibilityConverter
+                x:Key="StringNotEmptyToVisibilityConverter"
+                EmptyValue="Collapsed"
+                NotEmptyValue="Visible" />
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Border
+        Padding="8"
+        Margin="2"
+        Background="{ThemeResource LayerFillColorDefaultBrush}"
+        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+        CornerRadius="{StaticResource ControlCornerRadius}"
+        BorderThickness="1">
+        <StackPanel>
+            <TextBlock Text="Details details details" />
+        </StackPanel>
+    </Border>
+
+</UserControl>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/DetailsPane.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/DetailsPane.xaml
@@ -22,16 +22,35 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Border
+
+    <Grid
         Padding="8"
         Background="{ThemeResource LayerFillColorDefaultBrush}"
         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
         BorderThickness="1,0,0,0">
-        <StackPanel>
-            <TextBlock 
-                Text="{x:Bind ViewModel.Details.Title, Mode=OneWay}" 
-                Visibility="{x:Bind ViewModel.Details.Title, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}"/>
-            <!--<TextBlock Text="{x:Bind ViewModel.Details.Body, Mode=OneWay}" />-->
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Border 
+            Width="64" 
+            Height="64" 
+            Background="{ThemeResource AccentFillColorDefaultBrush}"
+            CornerRadius="{StaticResource ControlCornerRadius}">
+        </Border>
+
+        <TextBlock 
+            Grid.Row="1"
+            HorizontalAlignment="Center"
+            FontSize="20"
+            TextWrapping="WrapWholeWords"
+            Style="{StaticResource SubtitleTextBlockStyle}"
+            Text="{x:Bind ViewModel.Details.Title, Mode=OneWay}" 
+            Visibility="{x:Bind ViewModel.Details.Title, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}"/>
+
+        <ScrollViewer Grid.Row="2" HorizontalAlignment="Stretch">
             <toolkit:MarkdownTextBlock 
                 Text="{x:Bind ViewModel.Details.Body, Mode=OneWay}"
                 Background="Transparent"
@@ -40,7 +59,6 @@
                 Header3Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                 IsTextSelectionEnabled="True"
                 />
-        </StackPanel>
-    </Border>
-
+        </ScrollViewer>
+    </Grid>
 </UserControl>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/DetailsPane.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/DetailsPane.xaml
@@ -30,6 +30,8 @@
         BorderThickness="1">
         <StackPanel>
             <TextBlock Text="Details details details" />
+            <TextBlock Text="{x:Bind ViewModel.Details.Title, Mode=OneWay}" />
+            <TextBlock Text="{x:Bind ViewModel.Details.Body, Mode=OneWay}" />
         </StackPanel>
     </Border>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/DetailsPane.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/DetailsPane.xaml
@@ -9,6 +9,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:viewmodels="using:Microsoft.CmdPal.UI.ViewModels"
+    xmlns:toolkit="using:CommunityToolkit.WinUI.UI.Controls"
     Background="Transparent"
     mc:Ignorable="d">
 
@@ -23,15 +24,22 @@
 
     <Border
         Padding="8"
-        Margin="2"
         Background="{ThemeResource LayerFillColorDefaultBrush}"
         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-        CornerRadius="{StaticResource ControlCornerRadius}"
-        BorderThickness="1">
+        BorderThickness="1,0,0,0">
         <StackPanel>
-            <TextBlock Text="Details details details" />
-            <TextBlock Text="{x:Bind ViewModel.Details.Title, Mode=OneWay}" />
-            <TextBlock Text="{x:Bind ViewModel.Details.Body, Mode=OneWay}" />
+            <TextBlock 
+                Text="{x:Bind ViewModel.Details.Title, Mode=OneWay}" 
+                Visibility="{x:Bind ViewModel.Details.Title, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}"/>
+            <!--<TextBlock Text="{x:Bind ViewModel.Details.Body, Mode=OneWay}" />-->
+            <toolkit:MarkdownTextBlock 
+                Text="{x:Bind ViewModel.Details.Body, Mode=OneWay}"
+                Background="Transparent"
+                Header3FontSize="12"
+                Header3FontWeight="Normal"
+                Header3Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                IsTextSelectionEnabled="True"
+                />
         </StackPanel>
     </Border>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/DetailsPane.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/DetailsPane.xaml.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.CmdPal.UI.Controls;
+
+public sealed partial class DetailsPane : UserControl
+{
+    public DetailsPaneViewModel ViewModel { get; set; } = new();
+
+    public DetailsPane()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -4,7 +4,6 @@
 
 using CommunityToolkit.Common;
 using CommunityToolkit.Mvvm.Messaging;
-using CommunityToolkit.WinUI;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.UI.Dispatching;
@@ -77,21 +76,23 @@ public sealed partial class ListPage : Page,
                         // TODO: Handle failure case
                         System.Diagnostics.Debug.WriteLine(lvm.InitializeCommand.ExecutionTask.Exception);
 
-                        _ = _queue.EnqueueAsync(() =>
+                        // _ = _queue.EnqueueAsync(() =>
+                        _queue.TryEnqueue(new(() =>
                         {
                             LoadedState = ViewModelLoadedState.Error;
-                        });
+                        }));
                     }
                     else
                     {
-                        _ = _queue.EnqueueAsync(() =>
+                        // _ = _queue.EnqueueAsync(() =>
+                        _queue.TryEnqueue(new(() =>
                         {
                             var result = (bool)lvm.InitializeCommand.ExecutionTask.GetResultOrDefault()!;
 
                             ViewModel = lvm;
                             WeakReferenceMessenger.Default.Send<UpdateActionBarPage>(new(result ? lvm : null));
                             LoadedState = result ? ViewModelLoadedState.Loaded : ViewModelLoadedState.Error;
-                        });
+                        }));
                     }
                 });
             }
@@ -181,10 +182,10 @@ public sealed partial class ListPage : Page,
 
     public void Receive(ShowExceptionMessage message)
     {
-        _ = _queue.EnqueueAsync(() =>
+        _queue.TryEnqueue(new(() =>
         {
             LoadedState = ViewModelLoadedState.Error;
-        });
+        }));
     }
 }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -165,6 +165,17 @@ public sealed partial class ListPage : Page,
         if (ItemsList.SelectedItem is ListItemViewModel item)
         {
             ViewModel?.UpdateSelectedItemCommand.Execute(item);
+
+            if ((ViewModel?.ShowDetails ?? false) &&
+                item.HasDetails)
+            {
+                // TODO: fire a message off to the shellpage to make the
+                // details pane visible, with this item's details.
+            }
+            else
+            {
+                // TODO: fire message to hide the details pane.
+            }
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" />
     <PackageReference Include="CommunityToolkit.WinUI.Converters" />
     <PackageReference Include="CommunityToolkit.WinUI.Extensions" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
     <PackageReference Include="Microsoft.WindowsAppSDK" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml
@@ -38,6 +38,7 @@
                    IsNavigationStackEnabled="True" />
             
             <controls:DetailsPane 
+                x:Name="DetailsContent"
                 Grid.Column="1" 
                 Visibility="Visible" />
                    

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml
@@ -27,7 +27,21 @@
             Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
             BorderThickness="0,1,0,1">
-            <Frame Name="RootFrame" IsNavigationStackEnabled="True" />
+
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*" />
+                <ColumnDefinition x:Name="DetailsColumn" Width="2*" />
+            </Grid.ColumnDefinitions>
+
+            <Frame Name="RootFrame" 
+                   Grid.Column="0" 
+                   IsNavigationStackEnabled="True" />
+            
+            <controls:DetailsPane 
+                Grid.Column="1" 
+                Visibility="Visible" />
+                   
+        
         </Grid>
 
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
@@ -71,6 +71,7 @@ public sealed partial class ShellPage :
             {
                 _ = DispatcherQueue.TryEnqueue(() =>
                 {
+                    // TODO: also hide our details pane about here, if we had one
                     var pageViewModel = new ListViewModel(listPage, TaskScheduler.FromCurrentSynchronizationContext());
                     RootFrame.Navigate(typeof(ListPage), pageViewModel, _slideRightTransition);
                     SearchBox.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.CmdPal.UI.Pages;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
 
@@ -20,7 +21,9 @@ public sealed partial class ShellPage :
     Page,
     IRecipient<NavigateBackMessage>,
     IRecipient<NavigateToDetailsMessage>,
-    IRecipient<PerformCommandMessage>
+    IRecipient<PerformCommandMessage>,
+    IRecipient<ShowDetailsMessage>,
+    IRecipient<HideDetailsMessage>
 {
     private readonly DrillInNavigationTransitionInfo _drillInNavigationTransitionInfo = new();
 
@@ -36,6 +39,9 @@ public sealed partial class ShellPage :
         WeakReferenceMessenger.Default.Register<NavigateBackMessage>(this);
         WeakReferenceMessenger.Default.Register<NavigateToDetailsMessage>(this);
         WeakReferenceMessenger.Default.Register<PerformCommandMessage>(this);
+
+        WeakReferenceMessenger.Default.Register<ShowDetailsMessage>(this);
+        WeakReferenceMessenger.Default.Register<HideDetailsMessage>(this);
 
         RootFrame.Navigate(typeof(LoadingPage), ViewModel);
     }
@@ -95,5 +101,18 @@ public sealed partial class ShellPage :
         {
             // TODO logging
         }
+    }
+
+    public void Receive(ShowDetailsMessage message)
+    {
+        DetailsContent.ViewModel.Details = message.Details;
+        DetailsContent.Visibility = Visibility.Visible;
+        DetailsColumn.Width = new GridLength(2, GridUnitType.Star);
+    }
+
+    public void Receive(HideDetailsMessage message)
+    {
+        DetailsContent.Visibility = Visibility.Collapsed;
+        DetailsColumn.Width = GridLength.Auto;
     }
 }


### PR DESCRIPTION
* 5ff225216cab1690ce55088a0aa2fc1af013c867 Adds the ViewModel
* The rest of the commits work on adding it to the View. 

I had to re-add `CommunityToolkit.WinUI.UI.Controls.Markdown` to get the MD rendered again. 

