### PR TITLE
Minor Window Walker improvements

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Commands/SwitchToWindowCommand.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Commands/SwitchToWindowCommand.cs
@@ -2,11 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics;
 using Microsoft.CmdPal.Ext.WindowWalker.Components;
 using Microsoft.CmdPal.Ext.WindowWalker.Properties;
 using Microsoft.CmdPal.Extensions;
@@ -20,9 +16,23 @@ internal sealed partial class SwitchToWindowCommand : InvokableCommand
 
     public SwitchToWindowCommand(Window? window)
     {
-        Name = Resources.window_walker_top_level_command_title;
+        Name = Resources.switch_to_command_title;
         Icon = new(string.Empty);
         _window = window;
+        if (_window != null)
+        {
+            var p = Process.GetProcessById((int)_window.Process.ProcessID);
+            if (p != null)
+            {
+                try
+                {
+                    Icon = new(p.MainModule?.FileName);
+                }
+                catch
+                {
+                }
+            }
+        }
     }
 
     public override ICommandResult Invoke()

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Components/SearchController.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Components/SearchController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Microsoft.CmdPal.Ext.WindowWalker.Helpers;
 
 namespace Microsoft.CmdPal.Ext.WindowWalker.Components;
 
@@ -45,7 +46,7 @@ internal sealed class SearchController
     /// <summary>
     /// Gets the open window search results
     /// </summary>
-    internal List<SearchResult> SearchMatches => new List<SearchResult>(searchMatches ?? new List<SearchResult>()).OrderByDescending(x => x.Score).ToList();
+    internal List<SearchResult> SearchMatches => new List<SearchResult>(searchMatches ?? []).OrderByDescending(x => x.Score).ToList();
 
     /// <summary>
     /// Gets singleton Pattern
@@ -85,16 +86,9 @@ internal sealed class SearchController
     {
         System.Diagnostics.Debug.Print("Syncing WindowSearch result with OpenWindows Model");
 
-        List<Window> snapshotOfOpenWindows = OpenWindows.Instance.Windows;
+        var snapshotOfOpenWindows = OpenWindows.Instance.Windows;
 
-        if (string.IsNullOrWhiteSpace(SearchText))
-        {
-            searchMatches = AllOpenWindows(snapshotOfOpenWindows);
-        }
-        else
-        {
-            searchMatches = FuzzySearchOpenWindows(snapshotOfOpenWindows);
-        }
+        searchMatches = string.IsNullOrWhiteSpace(SearchText) ? AllOpenWindows(snapshotOfOpenWindows) : FuzzySearchOpenWindows(snapshotOfOpenWindows);
     }
 
     /// <summary>
@@ -104,7 +98,7 @@ internal sealed class SearchController
     /// <returns>Returns search results</returns>
     private List<SearchResult> FuzzySearchOpenWindows(List<Window> openWindows)
     {
-        List<SearchResult> result = new List<SearchResult>();
+        List<SearchResult> result = [];
         var searchStrings = new SearchString(searchText, SearchResult.SearchType.Fuzzy);
 
         foreach (var window in openWindows)
@@ -130,7 +124,7 @@ internal sealed class SearchController
     /// <returns>Returns search results</returns>
     private List<SearchResult> AllOpenWindows(List<Window> openWindows)
     {
-        List<SearchResult> result = new List<SearchResult>();
+        List<SearchResult> result = [];
 
         foreach (var window in openWindows)
         {
@@ -140,7 +134,11 @@ internal sealed class SearchController
             }
         }
 
-        return result.OrderBy(w => w.Result.Title).ToList();
+        return SettingsManager.Instance.InMruOrder
+            ? result.ToList()
+            : result
+                .OrderBy(w => w.Result.Title)
+                .ToList();
     }
 
     /// <summary>

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Helpers/SettingsManager.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Helpers/SettingsManager.cs
@@ -67,6 +67,12 @@ public class SettingsManager
         Resources.windowwalker_SettingExplorerSettingInfo_Description,
         false);
 
+    private readonly ToggleSetting _inMruOrder = new(
+        nameof(InMruOrder),
+        Resources.windowwalker_SettingInMruOrder,
+        Resources.windowwalker_SettingInMruOrder_Description,
+        true);
+
     public bool ResultsFromVisibleDesktopOnly => _resultsFromVisibleDesktopOnly.Value;
 
     public bool SubtitleShowPid => _subtitleShowPid.Value;
@@ -82,6 +88,8 @@ public class SettingsManager
     public bool HideKillProcessOnElevatedProcesses => _hideKillProcessOnElevatedProcesses.Value;
 
     public bool HideExplorerSettingInfo => _hideExplorerSettingInfo.Value;
+
+    public bool InMruOrder => _inMruOrder.Value;
 
     private static readonly JsonSerializerOptions _serializerOptions = new()
     {
@@ -113,6 +121,7 @@ public class SettingsManager
         _settings.Add(_openAfterKillAndClose);
         _settings.Add(_hideKillProcessOnElevatedProcesses);
         _settings.Add(_hideExplorerSettingInfo);
+        _settings.Add(_inMruOrder);
 
         // Load settings from file upon initialization
         LoadSettings();
@@ -127,10 +136,7 @@ public class SettingsManager
         }
     }
 
-    public Settings GetSettings()
-    {
-        return _settings;
-    }
+    public Settings GetSettings() => _settings;
 
     public void SaveSettings()
     {

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Pages/WindowWalkerListPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Pages/WindowWalkerListPage.cs
@@ -4,9 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.WindowWalker.Components;
 using Microsoft.CmdPal.Ext.WindowWalker.Properties;
 using Microsoft.CmdPal.Extensions;
@@ -22,14 +19,13 @@ internal sealed partial class WindowWalkerListPage : DynamicListPage, IDisposabl
 
     public WindowWalkerListPage()
     {
+        Icon = new("\ue8f9"); // SwitchApps
         Name = Resources.windowwalker_name;
         Id = "com.microsoft.cmdpal.windowwalker";
     }
 
-    public override void UpdateSearchText(string oldSearch, string newSearch)
-    {
-       RaiseItemsChanged(0);
-    }
+    public override void UpdateSearchText(string oldSearch, string newSearch) =>
+        RaiseItemsChanged(0);
 
     public List<WindowWalkerListItem> Query(string query)
     {
@@ -42,15 +38,12 @@ internal sealed partial class WindowWalkerListPage : DynamicListPage, IDisposabl
         WindowWalkerCommandsProvider.VirtualDesktopHelperInstance.UpdateDesktopList();
         OpenWindows.Instance.UpdateOpenWindowsList(_cancellationTokenSource.Token);
         SearchController.Instance.UpdateSearchText(query);
-        List<SearchResult> searchControllerResults = SearchController.Instance.SearchMatches;
+        var searchControllerResults = SearchController.Instance.SearchMatches;
 
         return ResultHelper.GetResultList(searchControllerResults, !string.IsNullOrEmpty(query), string.Empty, "\uE946");
     }
 
-    public override IListItem[] GetItems()
-    {
-        return Query(SearchText).ToArray();
-    }
+    public override IListItem[] GetItems() => Query(SearchText).ToArray();
 
     public void Dispose()
     {

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.CmdPal.Ext.WindowWalker.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Switch to.
+        /// </summary>
+        public static string switch_to_command_title {
+            get {
+                return ResourceManager.GetString("switch_to_command_title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to On all Desktops.
         /// </summary>
         public static string VirtualDesktopHelper_AllDesktops {
@@ -273,6 +282,24 @@ namespace Microsoft.CmdPal.Ext.WindowWalker.Properties {
         public static string windowwalker_SettingHideKillProcess {
             get {
                 return ResourceManager.GetString("windowwalker_SettingHideKillProcess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show windows in most-recently-used order.
+        /// </summary>
+        public static string windowwalker_SettingInMruOrder {
+            get {
+                return ResourceManager.GetString("windowwalker_SettingInMruOrder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When disabled, windows will be sorted by title.
+        /// </summary>
+        public static string windowwalker_SettingInMruOrder_Description {
+            get {
+                return ResourceManager.GetString("windowwalker_SettingInMruOrder_Description", resourceCulture);
             }
         }
         

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.resx
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.resx
@@ -202,11 +202,20 @@
   <data name="windowwalker_SettingSubtitleDesktopName_Description" xml:space="preserve">
     <value>This information is only shown in subtitle and tool tip, if you have at least two desktops.</value>
   </data>
+  <data name="windowwalker_SettingInMruOrder" xml:space="preserve">
+    <value>Show windows in most-recently-used order</value>
+  </data>
+  <data name="windowwalker_SettingInMruOrder_Description" xml:space="preserve">
+    <value>When disabled, windows will be sorted by title</value>
+  </data>
   <data name="windowwalker_NotResponding" xml:space="preserve">
     <value>Not Responding</value>
   </data>
   <data name="window_walker_top_level_command_title" xml:space="preserve">
     <value>Switch between open windows</value>
+  </data>
+  <data name="switch_to_command_title" xml:space="preserve">
+    <value>Switch to</value>
   </data>
   <data name="VirtualDesktopHelper_AllDesktops" xml:space="preserve">
     <value>On all Desktops</value>

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/WindowWalkerCommandsProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/WindowWalkerCommandsProvider.cs
@@ -13,7 +13,6 @@ namespace Microsoft.CmdPal.Ext.WindowWalker;
 public partial class WindowWalkerCommandsProvider : CommandProvider
 {
     private readonly CommandItem _windowWalkerPageItem;
-    private readonly SettingsManager _settingsManager = new();
 
     internal static readonly VirtualDesktopHelper VirtualDesktopHelperInstance = new();
 
@@ -22,7 +21,6 @@ public partial class WindowWalkerCommandsProvider : CommandProvider
         DisplayName = Resources.windowwalker_name;
         _windowWalkerPageItem = new CommandItem(new WindowWalkerListPage())
         {
-            Icon = new("\uE8B0"), // Window icon
             Title = Resources.window_walker_top_level_command_title,
             Subtitle = Resources.windowwalker_name,
             MoreCommands = [


### PR DESCRIPTION
* Add the app's icon, if we can
* Add a setting to display the results in-order (THE NEW DEFAULT)
* Change a couple strings to be tighter, less "power-user"-sounding
* Let the code formatter do its buisiness

Originally from 0b789ad, on `dev/migrie/f/stash-forms-should-submit`, which was buried like 7 branches deep. 