### PR TITLE
Make fallback commands work again

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -133,7 +133,6 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
                 this.Icon = model.Icon;
                 break;
 
-                // TODO! Icon
                 // TODO! MoreCommands array, which needs to also raise HasMoreCommands
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
@@ -19,6 +19,8 @@ public sealed class CommandProviderWrapper
 
     public ICommandItem[] TopLevelItems { get; private set; } = [];
 
+    public IFallbackCommandItem[] FallbackItems { get; private set; } = [];
+
     public CommandProviderWrapper(ICommandProvider provider)
     {
         _commandProvider = provider;
@@ -56,9 +58,16 @@ public sealed class CommandProviderWrapper
         var commands = await t.ConfigureAwait(false);
 
         // On a BG thread here
+        var fallbacks = _commandProvider.FallbackCommands();
+
         if (commands != null)
         {
             TopLevelItems = commands;
+        }
+
+        if (fallbacks != null)
+        {
+            FallbackItems = fallbacks;
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -59,13 +59,18 @@ public partial class MainListPage : DynamicListPage
         }
 
         return string.IsNullOrEmpty(SearchText)
-            ? _commands.Select(tlc => tlc).ToArray()
+            ? _commands.Select(tlc => tlc).Where(tlc => !string.IsNullOrEmpty(tlc.Title)).ToArray()
             : _filteredItems?.ToArray() ?? [];
     }
 
     public override void UpdateSearchText(string oldSearch, string newSearch)
     {
         /* handle changes to the filter text here */
+
+        foreach (var command in _commands)
+        {
+            command.TryUpdateFallbackText(newSearch);
+        }
 
         // Cleared out the filter text? easy. Reset _filteredItems, and bail out.
         if (string.IsNullOrEmpty(newSearch))

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/QuitCommandProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/QuitCommandProvider.cs
@@ -15,13 +15,8 @@ public partial class QuitCommandProvider : CommandProvider
 {
     private readonly QuitAction quitAction = new();
 
-    public override ICommandItem[] TopLevelCommands()
-    {
-        return [];
-    }
+    public override ICommandItem[] TopLevelCommands() => [];
 
-    public override IFallbackCommandItem[] FallbackCommands()
-    {
-        return [new FallbackCommandItem(quitAction) { Subtitle = "Exit Command Palette" }];
-    }
+    public override IFallbackCommandItem[] FallbackCommands() =>
+        [new FallbackCommandItem(quitAction) { Subtitle = "Exit Command Palette" }];
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -40,7 +40,12 @@ public partial class TopLevelCommandManager(IServiceProvider _serviceProvider) :
         await commandProvider.LoadTopLevelCommands();
         foreach (var i in commandProvider.TopLevelItems)
         {
-            TopLevelCommands.Add(new(new(i)));
+            TopLevelCommands.Add(new(new(i), false));
+        }
+
+        foreach (var i in commandProvider.FallbackItems)
+        {
+            TopLevelCommands.Add(new(new(i), true));
         }
     }
 

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ListHelpers.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ListHelpers.cs
@@ -16,6 +16,11 @@ public class ListHelpers
             return 1;
         }
 
+        if (string.IsNullOrEmpty(listItem.Title))
+        {
+            return 0;
+        }
+
         var nameMatch = StringMatcher.FuzzySearch(query, listItem.Title);
 
         // var locNameMatch = StringMatcher.FuzzySearch(query, NameLocalized);

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Shell/FallbackExecuteItem.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Shell/FallbackExecuteItem.cs
@@ -4,9 +4,6 @@
 
 using Microsoft.CmdPal.Ext.Shell.Commands;
 using Microsoft.CmdPal.Ext.Shell.Helpers;
-using Microsoft.CmdPal.Ext.Shell.Pages;
-using Microsoft.CmdPal.Ext.Shell.Properties;
-using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Shell;
@@ -20,17 +17,15 @@ internal sealed partial class FallbackExecuteItem : FallbackCommandItem
     {
         _executeItem = (ExecuteItem)this.Command!;
         Title = string.Empty;
+        _executeItem.Name = string.Empty;
         Subtitle = Properties.Resources.generic_run_command;
         Icon = new("\uE756");
-
-        // TODO: this is a bug in the current POC. I don't think Fallback items
-        // get icons set correctly.
-        _executeItem.Icon = Icon;
     }
 
     public override void UpdateQuery(string query)
     {
         _executeItem.Cmd = query;
+        _executeItem.Name = string.IsNullOrEmpty(query) ? string.Empty : Properties.Resources.generic_run_command;
         Title = query;
     }
 }


### PR DESCRIPTION
Add support for fallback commands again. Couple important parts:

* Lists shouldn't contain items with blank `Title`s. That's spec'd that way, and allows fallback items to hide themselves if they don't want to be shown for a given search string
* The CommandProviderWrapper, as well as extension infrastructure needs to know to get the fallbacks out of a commandprovider too. 
* `TopLevelCommandWrapper` needs to know when its model changes, to update itself in the list
