### PR TITLE
Don't kill the mainpage when typing a space

### DIFF
--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ListHelpers.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ListHelpers.cs
@@ -11,7 +11,7 @@ public class ListHelpers
     // Generate a score for a list item.
     public static int ScoreListItem(string query, ICommandItem listItem)
     {
-        if (string.IsNullOrEmpty(query))
+        if (string.IsNullOrEmpty(query) || string.IsNullOrWhiteSpace(query))
         {
             return 1;
         }


### PR DESCRIPTION
I think this is what @joadoumie  was seeing when he thought the main page crashed a lot. 

Some weird bug where the main page gcrashes with some frequency if the first thing you type is a space. Weird. `FuzzySearch` just can't handle the space