### PR TITLE
Down-weight fallback handlers

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandWrapper.cs
@@ -21,6 +21,8 @@ public partial class TopLevelCommandWrapper : ListItem
 
     public string Id { get; private set; } = string.Empty;
 
+    public bool IsFallback => _isFallback;
+
     public TopLevelCommandWrapper(ExtensionObject<ICommandItem> commandItem, bool isFallback)
         : base(commandItem.Unsafe?.Command ?? new NoOpCommand())
     {

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ListHelpers.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ListHelpers.cs
@@ -44,6 +44,17 @@ public class ListHelpers
             .Select(score => score.ListItem);
     }
 
+    public static IEnumerable<T> FilterList<T>(IEnumerable<T> items, string query, Func<string, T, int> scoreFunction)
+        where T : class
+    {
+        var scores = items
+            .Select(li => new Scored<T>() { Item = li, Score = scoreFunction(query, li) })
+            .Where(score => score.Score > 0)
+            .OrderByDescending(score => score.Score);
+        return scores
+            .Select(score => score.Item);
+    }
+
     /// <summary>
     /// Modifies the contents of `original` in-place, to match those of
     /// `newContents`. The canonical use being:
@@ -131,4 +142,10 @@ public struct ScoredListItem
 {
     public int Score;
     public IListItem ListItem;
+}
+
+public struct Scored<T>
+{
+    public int Score;
+    public T Item;
 }


### PR DESCRIPTION
As it stands, since the shell/run handler always exactly matches the `SearchText`, it _always_ shows up first in the results. 

That's annoying. Make it a little less popular. Sometimes, you just have to be mean to the kid that's really, really popular. 