### PR TITLE
Change single/double click behavior on list items

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -142,9 +142,13 @@ public sealed partial class ListPage : Page,
     [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "VS is too aggressive at pruning methods bound in XAML")]
     private void ListView_ItemClick(object sender, ItemClickEventArgs e)
     {
-        if (e.ClickedItem is ListItemViewModel item)
+        if (e.ClickedItem is ListItemViewModel item && item == ItemsList.SelectedItem)
         {
             ViewModel?.InvokeItemCommand.Execute(item);
+        }
+        else if (e.ClickedItem is ListItemViewModel item2)
+        {
+            ViewModel?.UpdateSelectedItemCommand.Execute(item2);
         }
     }
 


### PR DESCRIPTION
This PR adjusts the UX for single-clicking / double-clicking on list items. With this change: 

- A single-click on a list item will navigate the user to that list item. It will not automatically invoke the associated command.
- A double-click on a list item will invoke the command for the list item.

It is a really small code change, _but_ I have a suspicion that there are cleaner ways to handle what I'm doing. Since it is so small, I figured just creating the PR and getting quick @zadjii-msft feedback would do the trick.