### PR TITLE
Fix all the broken form pages

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkForm.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkForm.cs
@@ -54,10 +54,6 @@ internal sealed partial class AddBookmarkForm : Form
         return json;
     }
 
-    public override string DataJson() => throw new NotImplementedException();
-
-    public override string StateJson() => "{}";
-
     public override CommandResult SubmitForm(string payload)
     {
         var formInput = JsonNode.Parse(payload);

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderForm.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderForm.cs
@@ -67,10 +67,6 @@ internal sealed partial class BookmarkPlaceholderForm : Form
         return json;
     }
 
-    public override string DataJson() => throw new NotImplementedException();
-
-    public override string StateJson() => "{}";
-
     public override CommandResult SubmitForm(string payload)
     {
         var target = _bookmark;

--- a/src/modules/cmdpal/Exts/SpongebotExtension/SpongeSettingsForm.cs
+++ b/src/modules/cmdpal/Exts/SpongebotExtension/SpongeSettingsForm.cs
@@ -52,10 +52,6 @@ internal sealed partial class SpongeSettingsForm : Form
         return json;
     }
 
-    public override string DataJson() => throw new NotImplementedException();
-
-    public override string StateJson() => "{}";
-
     public override CommandResult SubmitForm(string payload)
     {
         var formInput = JsonNode.Parse(payload);

--- a/src/modules/cmdpal/Exts/YouTubeExtension/Pages/YouTubeAPIForm.cs
+++ b/src/modules/cmdpal/Exts/YouTubeExtension/Pages/YouTubeAPIForm.cs
@@ -48,10 +48,6 @@ internal sealed partial class YouTubeAPIForm : Form
         return json;
     }
 
-    public override string DataJson() => throw new NotImplementedException();
-
-    public override string StateJson() => "{}";
-
     public override CommandResult SubmitForm(string payload)
     {
         var formInput = JsonNode.Parse(payload);


### PR DESCRIPTION
Random nits, part the second

TRA is particular about form pages. It'll actually break itself if an extension throws an exception (which it should do). The POC was more forgiving (but technically incorrect)

Well, turns out, all the form pages we had did not give an F and just threw exceptions. They shouldn't! That's bad!