### PR TITLE
Actually add all the commands to the context menu

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -42,8 +42,8 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
         get
         {
             List<CommandContextItemViewModel> l = _defaultCommandContextItem == null ?
-                [_defaultCommandContextItem] :
-                new();
+                new() :
+                [_defaultCommandContextItem];
 
             l.AddRange(MoreCommands);
             return l;


### PR DESCRIPTION
Random nits, part the third

Whoops. Looks like the context menu was pretty specifically _not_ getting initialized with the default command. It definitely should.


