### PR TITLE
Spec out empty content

### DIFF
--- a/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
+++ b/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
@@ -1,7 +1,7 @@
 ---
 author: Mike Griese
 created on: 2024-07-19
-last updated: 2024-12-15
+last updated: 2024-12-31
 issue id: n/a
 ---
 
@@ -53,6 +53,7 @@ functionality.
     - [Pages](#pages)
       - [List Pages](#list-pages)
         - [Updating the list](#updating-the-list)
+        - [Empty content](#empty-content)
         - [Filtering the list](#filtering-the-list)
       - [Markdown Pages](#markdown-pages)
       - [Form Pages](#form-pages)
@@ -740,6 +741,7 @@ interface IListPage requires IPage, INotifyItemsChanged {
     IFilters Filters { get; };
     IGridProperties GridProperties { get; };
     Boolean HasMoreItems { get; };
+    ICommandItem EmptyContent { get; };
 
     IListItem[] GetItems();     
     void LoadMore();
@@ -1001,6 +1003,22 @@ the user to type a query and get a list of issues back.
 9. The extension does the background query to match
 10. The extension raises an `ItemsChanged(5)`, to indicate there are 5 results
 11. CmdPal calls `GetItems` to fetch the items.
+
+##### Empty content
+
+Developers can specify an `EmptyState` to customize the way the list page looks
+when there are no search results. This will control what's displayed to the user
+when both:
+* `IsLoading = false`
+* `GetItems()` returns null or an empty list
+
+This property is observable like anything else, which allows developers to
+change the empty state contextually. For example, consider a "search winget"
+extension:
+
+* If the user hasn't typed anything yet -> `Title="Start typing to search winget"`
+* If the user has typed and no results were found -> `Title="No results found"`,
+  `Subtitle="Your search '...' returned no packages on winget"`
 
 ##### Filtering the list
 

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ListPage.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ListPage.cs
@@ -14,6 +14,7 @@ public class ListPage : Page, IListPage
     private bool _hasMore;
     private IFilters? _filters;
     private IGridProperties? _gridProperties;
+    private ICommandItem? _emptyContent;
 
     public event TypedEventHandler<object, ItemsChangedEventArgs>? ItemsChanged;
 
@@ -74,6 +75,16 @@ public class ListPage : Page, IListPage
         {
             _gridProperties = value;
             OnPropertyChanged(nameof(GridProperties));
+        }
+    }
+
+    public ICommandItem? EmptyContent
+    {
+        get => _emptyContent;
+        set
+        {
+            _emptyContent = value;
+            OnPropertyChanged(nameof(EmptyContent));
         }
     }
 

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
@@ -264,6 +264,7 @@ namespace Microsoft.CmdPal.Extensions
         IFilters Filters { get; };
         IGridProperties GridProperties { get; };
         Boolean HasMoreItems { get; };
+        ICommandItem EmptyContent { get; };
     
         IListItem[] GetItems();     
         void LoadMore();


### PR DESCRIPTION
Specs #261


##### Empty content

Developers can specify an `EmptyState` to customize the way the list page looks
when there are no search results. This will control what's displayed to the user
when both:
* `IsLoading = false`
* `GetItems()` returns null or an empty list

This property is observable like anything else, which allows developers to
change the empty state contextually. For example, consider a "search winget"
extension:

* If the user hasn't typed anything yet -> `Title="Start typing to search winget"`
* If the user has typed and no results were found -> `Title="No results found"`,
  `Subtitle="Your search '...' returned no packages on winget"`