### PR TITLE
Tags should be Mode=OneWay in the XAML

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ActionBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ActionBar.xaml
@@ -38,7 +38,7 @@
                             SourceKey="{x:Bind Icon, Mode=OneWay}"
                             SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
 
-                        <TextBlock Grid.Column="1" Text="{x:Bind Title}" />
+                        <TextBlock Grid.Column="1" Text="{x:Bind Title, Mode=OneWay}" />
                     </Grid>
                 </ListViewItem>
             </DataTemplate>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -107,9 +107,9 @@
                     <ItemsRepeater
                         Grid.Column="2"
                         ItemTemplate="{StaticResource TagTemplate}"
-                        ItemsSource="{x:Bind Tags}"
+                        ItemsSource="{x:Bind Tags, Mode=OneWay}"
                         Layout="{StaticResource HorizontalStackLayout}"
-                        Visibility="{x:Bind HasTags}" />
+                        Visibility="{x:Bind HasTags, Mode=OneWay}" />
                 </Grid>
             </ListViewItem>
         </DataTemplate>


### PR DESCRIPTION
Yea, this one's stupid. I spent too long debugging why changing the list of tags in an extension didn't do anything. Turns out, we just never had XAML listen for the PropertyChanged. That hurts.