### PR TITLE
Support CommandResult.GoBack in the host

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using CommunityToolkit.Common;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.UI.ViewModels;
@@ -174,6 +173,12 @@ public sealed partial class ShellPage :
                         {
                             // Go back to the main page, but keep it open
                             GoHome();
+                            break;
+                        }
+
+                    case CommandResultKind.GoBack:
+                        {
+                            GoBack();
                             break;
                         }
 


### PR DESCRIPTION
I think I added this to the spec while there was like, 80 branches flying around and never actually merged support for it in the host app. Oops.
