### PR TITLE
Change the default debounce timer from 100ms to 50ms

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -159,10 +159,10 @@ public sealed partial class SearchBar : UserControl,
                     CurrentPageViewModel.Filter = FilterBox.Text;
                 }
             },
-            //// Couldn't find a good recommendation/resource for value here.
+            //// Couldn't find a good recommendation/resource for value here. PT uses 50ms as default, so that is a reasonable default 
             //// This seems like a useful testing site for typing times: https://keyboardtester.info/keyboard-latency-test/
-            //// i.e. if another keyboard press comes in within 100ms of the last, we'll wait before we fire off the request
-            interval: TimeSpan.FromMilliseconds(100),
+            //// i.e. if another keyboard press comes in within 50ms of the last, we'll wait before we fire off the request
+            interval: TimeSpan.FromMilliseconds(50),
             //// If we're not already waiting, and this is blanking out or the first character type, we'll start filtering immediately instead to appear more responsive and either clear the filter to get back home faster or at least chop to the first starting letter.
             immediate: FilterBox.Text.Length <= 1);
     }


### PR DESCRIPTION
PowerToys Run has 50ms as the default input smoothing: 

![image](https://github.com/user-attachments/assets/69a8b823-b6ed-46b6-afbf-08209e10b97a)

This PR simply changes the current value from 100ms to 50ms. This causes a noticeable improvement for fast typers. 

