### PR TITLE
Allow both light and dark icons

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -25,7 +25,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
 
     public string Subtitle { get; private set; } = string.Empty;
 
-    public IconDataType Icon { get; private set; } = new(string.Empty);
+    public IconInfo Icon { get; private set; } = new(string.Empty);
 
     public ExtensionObject<ICommand> Command { get; private set; } = new(null);
 
@@ -72,9 +72,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
         Subtitle = model.Subtitle;
 
         var listIcon = model.Icon;
-        Icon = !string.IsNullOrEmpty(listIcon.Icon) ?
-            listIcon :
-            Command.Unsafe!.Icon;
+        Icon = listIcon ?? Command.Unsafe!.Icon;
 
         var more = model.MoreCommands;
         if (more != null)
@@ -142,7 +140,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
                 break;
             case nameof(Icon):
                 var listIcon = model.Icon;
-                Icon = !string.IsNullOrEmpty(listIcon.Icon) ? listIcon : Command.Unsafe!.Icon;
+                Icon = listIcon != null ? listIcon : Command.Unsafe!.Icon;
                 break;
 
                 // TODO! MoreCommands array, which needs to also raise HasMoreCommands

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
@@ -13,9 +13,7 @@ public partial class DetailsViewModel(IDetails _details, IPageContext context) :
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
-    public IconInfo HeroImage { get; private set; } = new(string.Empty);
-
-    // public bool HasHeroImage => !string.IsNullOrEmpty(HeroImage.Icon) || HeroImage.Data != null;
+    public IconInfo HeroImage { get; private set; } = new(string.Empty)
 
     // TODO: Metadata is an array of IDetailsElement,
     // where IDetailsElement = {IDetailsTags, IDetailsLink, IDetailsSeparator}
@@ -38,7 +36,5 @@ public partial class DetailsViewModel(IDetails _details, IPageContext context) :
         UpdateProperty(nameof(Title));
         UpdateProperty(nameof(Body));
         UpdateProperty(nameof(HeroImage));
-
-        // UpdateProperty(nameof(HasHeroImage));
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
@@ -13,9 +13,9 @@ public partial class DetailsViewModel(IDetails _details, IPageContext context) :
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
-    public IconDataType HeroImage { get; private set; } = new(string.Empty);
+    public IconInfo HeroImage { get; private set; } = new(string.Empty);
 
-    public bool HasHeroImage => !string.IsNullOrEmpty(HeroImage.Icon) || HeroImage.Data != null;
+    // public bool HasHeroImage => !string.IsNullOrEmpty(HeroImage.Icon) || HeroImage.Data != null;
 
     // TODO: Metadata is an array of IDetailsElement,
     // where IDetailsElement = {IDetailsTags, IDetailsLink, IDetailsSeparator}
@@ -38,6 +38,7 @@ public partial class DetailsViewModel(IDetails _details, IPageContext context) :
         UpdateProperty(nameof(Title));
         UpdateProperty(nameof(Body));
         UpdateProperty(nameof(HeroImage));
-        UpdateProperty(nameof(HasHeroImage));
+
+        // UpdateProperty(nameof(HasHeroImage));
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
@@ -40,7 +40,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
 
     public bool IsLoading { get; private set; } = true;
 
-    public IconDataType Icon { get; private set; } = new(string.Empty);
+    public IconInfo Icon { get; private set; } = new(string.Empty);
 
     public PageViewModel(IPage model, TaskScheduler scheduler)
         : base(null)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TagViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TagViewModel.cs
@@ -21,9 +21,10 @@ public partial class TagViewModel(ITag _tag, IPageContext context) : ExtensionOb
 
     public OptionalColor Background { get; private set; }
 
-    public IconDataType Icon { get; private set; } = new(string.Empty);
+    public IconInfo Icon { get; private set; } = new(string.Empty);
 
-    public bool HasIcon => !string.IsNullOrEmpty(Icon.Icon);
+    // TODO Terrible. When we redo the icons in tags, make this something the view exposes
+    public bool HasIcon => !string.IsNullOrEmpty(Icon.Light.Icon);
 
     public ExtensionObject<ICommand> Command { get; private set; } = new(null);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandWrapper.cs
@@ -46,7 +46,7 @@ public partial class TopLevelCommandWrapper : ListItem
 
             Title = model.Title;
             Subtitle = model.Subtitle;
-            Icon = new(model.Icon.Icon);
+            Icon = model.Icon;
             MoreCommands = model.MoreCommands;
 
             model.PropChanged += Model_PropChanged;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
@@ -91,7 +91,8 @@ public partial class IconBox : ContentControl
                 // _ = @this._queue.EnqueueAsync(() =>
                 @this._queue.TryEnqueue(new(() =>
                 {
-                    var eventArgs = new SourceRequestedEventArgs(e.NewValue);
+                    var requestedTheme = @this.ActualTheme;
+                    var eventArgs = new SourceRequestedEventArgs(e.NewValue, requestedTheme);
 
                     if (@this.SourceRequested != null)
                     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SourceRequestedEventArgs.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SourceRequestedEventArgs.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.Common.Deferred;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.CmdPal.UI.Controls;
@@ -10,9 +11,11 @@ namespace Microsoft.CmdPal.UI.Controls;
 /// <summary>
 /// See <see cref="IconBox.SourceRequested"/> event.
 /// </summary>
-public class SourceRequestedEventArgs(object? key) : DeferredEventArgs
+public class SourceRequestedEventArgs(object? key, ElementTheme requestedTheme) : DeferredEventArgs
 {
     public object? Key { get; private set; } = key;
 
     public IconSource? Value { get; set; }
+
+    public ElementTheme Theme => requestedTheme;
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/IconCacheProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/IconCacheProvider.cs
@@ -32,5 +32,14 @@ public static partial class IconCacheProvider
 
             deferral.Complete();
         }
+        else if (args.Key is IconInfo iconInfo)
+        {
+            var deferral = args.GetDeferral();
+
+            var data = args.Theme == Microsoft.UI.Xaml.ElementTheme.Dark ? iconInfo.Dark : iconInfo.Light;
+            args.Value = await IconService.GetIconSource(data);
+
+            deferral.Complete();
+        }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml
@@ -168,10 +168,9 @@
                         x:Name="HeroImageBorder"
                         Width="64"
                         Height="64"
-                        x:Load="{x:Bind IsLoaded, Mode=OneWay}"
                         SourceKey="{x:Bind ViewModel.Details.HeroImage, Mode=OneWay}"
                         SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}"
-                        Visibility="{x:Bind ViewModel.Details.HasHeroImage, Mode=OneWay}" />
+                        Visibility="{x:Bind HasHeroImage, Mode=OneWay}" />
 
                     <TextBlock
                         Grid.Row="1"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.UI.ViewModels;
@@ -26,13 +27,16 @@ public sealed partial class ShellPage :
     IRecipient<HideDetailsMessage>,
     IRecipient<ClearSearchMessage>,
     IRecipient<HandleCommandResultMessage>,
-    IRecipient<LaunchUriMessage>
+    IRecipient<LaunchUriMessage>,
+    INotifyPropertyChanged
 {
     private readonly DispatcherQueue _queue = DispatcherQueue.GetForCurrentThread();
 
     private readonly SlideNavigationTransitionInfo _slideRightTransition = new() { Effect = SlideNavigationTransitionEffect.FromRight };
 
     public ShellViewModel ViewModel { get; private set; } = App.Current.Services.GetService<ShellViewModel>()!;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public ShellPage()
     {
@@ -207,6 +211,8 @@ public sealed partial class ShellPage :
     {
         ViewModel.Details = message.Details;
         ViewModel.IsDetailsVisible = true;
+
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasHeroImage)));
     }
 
     public void Receive(HideDetailsMessage message) => HideDetails();
@@ -261,6 +267,24 @@ public sealed partial class ShellPage :
             // Note, this shortcuts and fights a bit with our LoadPageViewModel above, but we want to better fast display and incrementally load anyway
             // We just need to reconcile our loading systems a bit more in the future.
             ViewModel.CurrentPage = page;
+        }
+    }
+
+    public bool HasHeroImage
+    {
+        get
+        {
+            var requestedTheme = ActualTheme;
+            var iconInfo = ViewModel.Details?.HeroImage;
+            var data = requestedTheme == Microsoft.UI.Xaml.ElementTheme.Dark ? iconInfo?.Dark : iconInfo?.Light;
+
+            // We have an icon, AND EITHER:
+            //      We have a string icon, OR
+            //      we have a data blob
+            var hasIcon = (data != null) &&
+                    (!string.IsNullOrEmpty(data.Icon) ||
+                    data.Data != null);
+            return hasIcon;
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
@@ -212,6 +212,8 @@ public sealed partial class ShellPage :
         ViewModel.Details = message.Details;
         ViewModel.IsDetailsVisible = true;
 
+        // Trigger a re-evaluation of whether we have a hero image based on
+        // the current theme
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(HasHeroImage)));
     }
 
@@ -270,13 +272,20 @@ public sealed partial class ShellPage :
         }
     }
 
+    /// <summary>
+    /// Gets a value indicating whether determines if the current Details have a HeroImage, given the theme
+    /// we're currently in. This needs to be evaluated in the view, because the
+    /// viewModel doesn't actually know what the current theme is.
+    /// </summary>
     public bool HasHeroImage
     {
         get
         {
             var requestedTheme = ActualTheme;
             var iconInfo = ViewModel.Details?.HeroImage;
-            var data = requestedTheme == Microsoft.UI.Xaml.ElementTheme.Dark ? iconInfo?.Dark : iconInfo?.Light;
+            var data = requestedTheme == Microsoft.UI.Xaml.ElementTheme.Dark ?
+                iconInfo?.Dark :
+                iconInfo?.Light;
 
             // We have an icon, AND EITHER:
             //      We have a string icon, OR

--- a/src/modules/cmdpal/doc/initial-sdk-spec/generate-interface.ps1
+++ b/src/modules/cmdpal/doc/initial-sdk-spec/generate-interface.ps1
@@ -74,6 +74,15 @@ namespace Microsoft.CmdPal.Extensions
     };
     
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
+    runtimeclass IconInfo {
+        IconInfo(String iconString);
+        IconInfo(IconDataType lightIcon, IconDataType darkIcon);
+
+        IconDataType Light { get; };
+        IconDataType Dark { get; };
+    };
+
+    [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
     runtimeclass KeyChord
     {
         KeyChord();

--- a/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
+++ b/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
@@ -1301,7 +1301,7 @@ block, and the generator will pull this into the file first.   -->
 
 ```c#
 interface ITag {
-    IconDataType Icon { get; };
+    IconInfo Icon { get; };
     String Text { get; };
     OptionalColor Foreground { get; };
     OptionalColor Background { get; };
@@ -1316,7 +1316,7 @@ interface IDetailsElement {
     IDetailsData Data { get; };
 }
 interface IDetails {
-    IconDataType HeroImage { get; };
+    IconInfo HeroImage { get; };
     String Title { get; };
     String Body { get; };
     IDetailsElement[] Metadata { get; };

--- a/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
+++ b/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
@@ -59,7 +59,7 @@ functionality.
       - [Form Pages](#form-pages)
     - [Other types](#other-types)
       - [`ContextItem`s](#contextitems)
-      - [`IconDataType`](#icondatatype)
+      - [Icons - `IconInfo` and `IconDataType`](#icons---iconinfo-and-icondatatype)
       - [`OptionalColor`](#optionalcolor)
       - [`Details`](#details)
       - [`INotifyPropChanged`](#inotifypropchanged)
@@ -533,7 +533,7 @@ Use `cs` for samples.
 interface ICommand requires INotifyPropChanged{
     String Name{ get; };
     String Id{ get; };
-    IconDataType Icon{ get; };
+    IconInfo Icon{ get; };
 }
 
 enum CommandResultKind {
@@ -708,7 +708,7 @@ interface IContextItem {}
 interface ICommandItem requires INotifyPropChanged {
     ICommand Command{ get; };
     IContextItem[] MoreCommands{ get; };
-    IconDataType Icon{ get; };
+    IconInfo Icon{ get; };
     String Title{ get; };
     String Subtitle{ get; };
 } 
@@ -1037,7 +1037,7 @@ interface ISeparatorFilterItem requires IFilterItem {}
 interface IFilter requires IFilterItem {
     String Id { get; };
     String Name { get; };
-    IconDataType Icon { get; };
+    IconInfo Icon { get; };
 }
 
 interface IFilters {
@@ -1215,7 +1215,7 @@ flyout. Mostly, these are just commands and seperators.
 If an `ICommandContextItem` has `MoreCommands`, then when it's invoked, we'll
 create a sub-menu with those items in it.
 
-#### `IconDataType`
+#### Icons - `IconInfo` and `IconDataType`
 
 This is a wrapper type for passing information about an icon to DevPal. This
 allows extensions to specify apps in a variety of ways, including:
@@ -1235,6 +1235,13 @@ struct IconDataType {
 
     String Icon { get; };
     Windows.Storage.Streams.IRandomAccessStreamReference Data { get; };
+}
+struct IconInfo {
+    IconInfo(String iconString);
+    IconInfo(IconDataType lightIcon, IconDataType darkIcon);
+
+    IconDataType Light { get; };
+    IconDataType Dark { get; };
 }
 ```
 
@@ -1375,7 +1382,7 @@ interface ICommandProvider requires Windows.Foundation.IClosable, INotifyItemsCh
 {
     String Id { get; };
     String DisplayName { get; };
-    IconDataType Icon { get; };
+    IconInfo Icon { get; };
     ICommandSettings Settings { get; };
     Boolean Frozen { get; };
 

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Command.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Command.cs
@@ -8,7 +8,7 @@ public class Command : BaseObservable, ICommand
 {
     private string _name = string.Empty;
     private string _id = string.Empty;
-    private IconDataType _icon = new(string.Empty);
+    private IconInfo _icon = new(string.Empty);
 
     public string Name
     {
@@ -22,7 +22,7 @@ public class Command : BaseObservable, ICommand
 
     public string Id { get => _id; protected set => _id = value; }
 
-    public IconDataType Icon
+    public IconInfo Icon
     {
         get => _icon;
         set

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/CommandItem.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/CommandItem.cs
@@ -6,13 +6,13 @@ namespace Microsoft.CmdPal.Extensions.Helpers;
 
 public partial class CommandItem : BaseObservable, ICommandItem
 {
-    private IconDataType? _icon;
+    private IconInfo? _icon;
     private string _title = string.Empty;
     private string _subtitle = string.Empty;
     private ICommand? _command;
     private IContextItem[] _moreCommands = [];
 
-    public IconDataType? Icon
+    public IconInfo? Icon
     {
         get => _icon ?? _command?.Icon;
         set

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/CommandProvider.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/CommandProvider.cs
@@ -12,7 +12,7 @@ public abstract partial class CommandProvider : ICommandProvider
 
     private string _displayName = string.Empty;
 
-    private IconDataType _icon = new(string.Empty);
+    private IconInfo _icon = new(string.Empty);
 
     private ICommandSettings? _settings;
 
@@ -20,7 +20,7 @@ public abstract partial class CommandProvider : ICommandProvider
 
     public string DisplayName { get => _displayName; protected set => _displayName = value; }
 
-    public IconDataType Icon { get => _icon; protected set => _icon = value; }
+    public IconInfo Icon { get => _icon; protected set => _icon = value; }
 
     public event TypedEventHandler<object, ItemsChangedEventArgs>? ItemsChanged;
 

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Details.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Details.cs
@@ -6,12 +6,12 @@ namespace Microsoft.CmdPal.Extensions.Helpers;
 
 public class Details : BaseObservable, IDetails
 {
-    private IconDataType _heroImage = new(string.Empty);
+    private IconInfo _heroImage = new(string.Empty);
     private string _title = string.Empty;
     private string _body = string.Empty;
     private IDetailsElement[] _metadata = [];
 
-    public IconDataType HeroImage
+    public IconInfo HeroImage
     {
         get => _heroImage;
         set

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Filter.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Filter.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CmdPal.Extensions.Helpers;
 
 public class Filter : IFilter
 {
-    public IconDataType Icon => throw new NotImplementedException();
+    public IconInfo Icon => throw new NotImplementedException();
 
     public string Id => throw new NotImplementedException();
 

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Tag.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/Tag.cs
@@ -8,7 +8,7 @@ public class Tag : BaseObservable, ITag
 {
     private OptionalColor _foreground;
     private OptionalColor _background;
-    private IconDataType _icon = new(string.Empty);
+    private IconInfo _icon = new(string.Empty);
     private string _text = string.Empty;
     private string _toolTip = string.Empty;
     private ICommand? _command;
@@ -33,7 +33,7 @@ public class Tag : BaseObservable, ITag
         }
     }
 
-    public IconDataType Icon
+    public IconInfo Icon
     {
         get => _icon;
         set

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/IconDataType.cpp
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/IconDataType.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
 #include "IconDataType.h"
 #include "IconDataType.g.cpp"
+#include "IconInfo.g.cpp"
  

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/IconDataType.h
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/IconDataType.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "IconDataType.g.h"
+#include "IconInfo.g.h"
 
 namespace winrt::Microsoft::CmdPal::Extensions::implementation
 {
@@ -18,13 +19,34 @@ namespace winrt::Microsoft::CmdPal::Extensions::implementation
         
         til::property<hstring> Icon;
         til::property<Windows::Storage::Streams::IRandomAccessStreamReference> Data;
-        
-
     };
 }
 namespace winrt::Microsoft::CmdPal::Extensions::factory_implementation
 {
     struct IconDataType : IconDataTypeT<IconDataType, implementation::IconDataType>
+    {
+    };
+}
+
+namespace winrt::Microsoft::CmdPal::Extensions::implementation
+{
+    struct IconInfo : IconInfoT<IconInfo>
+    {
+        IconInfo(hstring iconPath) :
+            Light(iconPath),
+            Dark(iconPath){};
+
+        IconInfo(Extensions::IconDataType light, Extensions::IconDataType dark) :
+            Light(light),
+            Dark(dark) {};
+        
+        til::property<Extensions::IconDataType> Light;
+        til::property<Extensions::IconDataType> Dark;       
+    };
+}
+namespace winrt::Microsoft::CmdPal::Extensions::factory_implementation
+{
+    struct IconInfo : IconInfoT<IconInfo, implementation::IconInfo>
     {
     };
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
@@ -140,7 +140,7 @@ namespace Microsoft.CmdPal.Extensions
     
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
     interface ITag {
-        IconDataType Icon { get; };
+        IconInfo Icon { get; };
         String Text { get; };
         OptionalColor Foreground { get; };
         OptionalColor Background { get; };
@@ -158,7 +158,7 @@ namespace Microsoft.CmdPal.Extensions
     }
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
     interface IDetails {
-        IconDataType HeroImage { get; };
+        IconInfo HeroImage { get; };
         String Title { get; };
         String Body { get; };
         IDetailsElement[] Metadata { get; };

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
@@ -24,6 +24,15 @@ namespace Microsoft.CmdPal.Extensions
     };
     
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
+    runtimeclass IconInfo {
+        IconInfo(String iconString);
+        IconInfo(IconDataType lightIcon, IconDataType darkIcon);
+
+        IconDataType Light { get; };
+        IconDataType Dark { get; };
+    };
+
+    [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
     runtimeclass KeyChord
     {
         KeyChord();
@@ -62,7 +71,7 @@ namespace Microsoft.CmdPal.Extensions
     interface ICommand requires INotifyPropChanged{
         String Name{ get; };
         String Id{ get; };
-        IconDataType Icon{ get; };
+        IconInfo Icon{ get; };
     }
     
     enum CommandResultKind {
@@ -106,7 +115,7 @@ namespace Microsoft.CmdPal.Extensions
     interface IFilter requires IFilterItem {
         String Id { get; };
         String Name { get; };
-        IconDataType Icon { get; };
+        IconInfo Icon { get; };
     }
     
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
@@ -226,7 +235,7 @@ namespace Microsoft.CmdPal.Extensions
     interface ICommandItem requires INotifyPropChanged {
         ICommand Command{ get; };
         IContextItem[] MoreCommands{ get; };
-        IconDataType Icon{ get; };
+        IconInfo Icon{ get; };
         String Title{ get; };
         String Subtitle{ get; };
     } 
@@ -315,7 +324,7 @@ namespace Microsoft.CmdPal.Extensions
     {
         String Id { get; };
         String DisplayName { get; };
-        IconDataType Icon { get; };
+        IconInfo Icon { get; };
         ICommandSettings Settings { get; };
         Boolean Frozen { get; };
     


### PR DESCRIPTION
This adds one _last_ change to the API to allow apps to specify different icons for light and dark mode. 

If it's important to an app to specify different icons for light vs dark mode, then `IconInfo` is exactly what you want to use. It contains _two_ `IconDataType`s, for two different icons. Simple as that. 

And to keep things even easier, I slapped on a `IconInfo(string)` constructor, so that you can easily build a `IconInfo` with both icons set to the same string. Especially useful for font icons, which we're using everywhere already. That allows almost all the extensions to have _no code change_ here, so that's super!

Some of the places where we were evaluating if an icon existed or not - that needs to move into the view. `ShellPage.xaml.cs` does one variant of that already for `IDetails.HeroImage`. The view is the only part of the app that knows what the theme is. 

Closes #78 

