### PR TITLE
When an extension item fails to load, replace it with an error item

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -67,9 +67,9 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
 
         Command = new(model.Command);
 
-        // The way we're using this, this call to initalize Name is
+        // The way we're using this, this call to initialize Name is
         // particularly unsafe. For top-level commands, we wrap the
-        // _CommandItemo_ in a TopLevelCommandWrapper. But the secret prblem
+        // _CommandItem_ in a TopLevelCommandWrapper. But the secret problem
         // is: if the extension crashes, then the next time the MainPage
         // fetches items, we'll grab the TopLevelCommandWrapper, and try to get
         // the .Name out of its Command. But its .Command has died, so we

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -67,6 +67,15 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
 
         Command = new(model.Command);
 
+        // The way we're using this, this call to initalize Name is
+        // particularly unsafe. For top-level commands, we wrap the
+        // _CommandItemo_ in a TopLevelCommandWrapper. But the secret prblem
+        // is: if the extension crashes, then the next time the MainPage
+        // fetches items, we'll grab the TopLevelCommandWrapper, and try to get
+        // the .Name out of its Command. But its .Command has died, so we
+        // explode here.
+        // (Icon probably has the same issue)
+        // When we have proper stubs for TLC's, this probably won't be an issue anymore.
         Name = model.Command?.Name ?? string.Empty;
         Title = model.Title;
         Subtitle = model.Subtitle;
@@ -107,6 +116,26 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
         model.PropChanged += Model_PropChanged;
 
         // _initialized = true;
+    }
+
+    public bool SafeInitializeProperties()
+    {
+        try
+        {
+            InitializeProperties();
+            return true;
+        }
+        catch (Exception)
+        {
+            Command = new(null);
+            Name = "Error";
+            Title = "Error";
+            Subtitle = "Item failed to load";
+            MoreCommands = [];
+            Icon = new("❌");
+        }
+
+        return false;
     }
 
     private void Model_PropChanged(object sender, PropChangedEventArgs args)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -95,7 +95,7 @@ public partial class ListViewModel : PageViewModel
             foreach (var item in newItems)
             {
                 ListItemViewModel viewModel = new(item, this);
-                viewModel.InitializeProperties();
+                viewModel.SafeInitializeProperties();
                 newViewModels.Add(viewModel);
             }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -95,8 +95,12 @@ public partial class ListViewModel : PageViewModel
             foreach (var item in newItems)
             {
                 ListItemViewModel viewModel = new(item, this);
-                viewModel.SafeInitializeProperties();
-                newViewModels.Add(viewModel);
+
+                // If an item fails to load, silently ignore it.
+                if (viewModel.SafeInitializeProperties())
+                {
+                    newViewModels.Add(viewModel);
+                }
             }
 
             // Now that we have new ViewModels for everything from the

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandWrapper.cs
@@ -9,20 +9,12 @@ using Microsoft.CmdPal.UI.ViewModels.Models;
 namespace Microsoft.CmdPal.UI.ViewModels;
 
 /// <summary>
-/// Abstraction of a top-level command item. Currently owns just a live ICommandItem
+/// Abstraction of a top-level command. Currently owns just a live ICommandItem
 /// from an extension (or in-proc command provider), but in the future will
 /// also support stub top-level items.
-///
-/// More correctly, this is a "TopLevelCommand**Item**Wrapper". It wraps the
-/// CommandItem, but the ICommand itself is relatively raw.
 /// </summary>
 public partial class TopLevelCommandWrapper : ListItem
 {
-    // We may want to in the future, create our own safe wrapper around the
-    // `ICommand` itself. There's a couple things that we get straight out of
-    // the Command - namely .Nmae and .Icon, and we don't want to have to do a
-    // x-proc call every time just to fetch those (after we've already fetched
-    // them)
     public ExtensionObject<ICommandItem> Model { get; }
 
     private readonly bool _isFallback;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandWrapper.cs
@@ -9,12 +9,20 @@ using Microsoft.CmdPal.UI.ViewModels.Models;
 namespace Microsoft.CmdPal.UI.ViewModels;
 
 /// <summary>
-/// Abstraction of a top-level command. Currently owns just a live ICommandItem
+/// Abstraction of a top-level command item. Currently owns just a live ICommandItem
 /// from an extension (or in-proc command provider), but in the future will
 /// also support stub top-level items.
+///
+/// More correctly, this is a "TopLevelCommand**Item**Wrapper". It wraps the
+/// CommandItem, but the ICommand itself is relatively raw.
 /// </summary>
 public partial class TopLevelCommandWrapper : ListItem
 {
+    // We may want to in the future, create our own safe wrapper around the
+    // `ICommand` itself. There's a couple things that we get straight out of
+    // the Command - namely .Nmae and .Icon, and we don't want to have to do a
+    // x-proc call every time just to fetch those (after we've already fetched
+    // them)
     public ExtensionObject<ICommandItem> Model { get; }
 
     private readonly bool _isFallback;


### PR DESCRIPTION
Right now, the main page really explodes if an extension dies. It really does not like it. 

Instead, this PR changes it so that if we fail to load the properties from an ICommandItem, we won't kill the whole page, we'll just replace that _single_ item with an error item. This looks like:

![image](https://github.com/user-attachments/assets/c5e74af1-5d79-47db-81f9-ab6ea1448881)

(which will look better after #265)