### PR TITLE
Spec `GoToPageArgs.NavigationMode`

### DIFF
--- a/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
+++ b/src/modules/cmdpal/doc/initial-sdk-spec/initial-sdk-spec.md
@@ -544,6 +544,13 @@ enum CommandResultKind {
     KeepOpen,   // Do nothing.
     GoToPage,   // Go to another page. GoToPageArgs will tell you where.
 };
+
+enum NavigationMode {
+    Push,   // Push the target page onto the navigation stack
+    GoBack, // Go back one page before navigating to the target page
+    GoHome, // Go back to the home page before navigating to the target page
+};
+
 [uuid("f9d6423b-bd5e-44bb-a204-2f5c77a72396")]
 interface ICommandResultArgs{};
 interface ICommandResult {
@@ -552,6 +559,7 @@ interface ICommandResult {
 }
 interface IGoToPageArgs requires ICommandResultArgs{
     String PageId { get; };
+    NavigationMode NavigationMode { get; };
 }
 
 // This is a "leaf" of the UI. This is something that can be "done" by the user.

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/GoToPageArgs.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/GoToPageArgs.cs
@@ -7,4 +7,6 @@ namespace Microsoft.CmdPal.Extensions.Helpers;
 public class GoToPageArgs : IGoToPageArgs
 {
     public required string PageId { get; set; }
+
+    public NavigationMode NavigationMode { get; set; } = NavigationMode.Push;
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions/Microsoft.CmdPal.Extensions.idl
@@ -73,6 +73,13 @@ namespace Microsoft.CmdPal.Extensions
         KeepOpen,   // Do nothing.
         GoToPage,   // Go to another page. GoToPageArgs will tell you where.
     };
+    
+    enum NavigationMode {
+        Push,   // Push the target page onto the navigation stack
+        GoBack, // Go back one page before navigating to the target page
+        GoHome, // Go back to the home page before navigating to the target page
+    };
+    
     [uuid("f9d6423b-bd5e-44bb-a204-2f5c77a72396")]
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
     interface ICommandResultArgs{};
@@ -84,6 +91,7 @@ namespace Microsoft.CmdPal.Extensions
     [contract(Microsoft.CmdPal.Extensions.ExtensionsContract, 1)]
     interface IGoToPageArgs requires ICommandResultArgs{
         String PageId { get; };
+        NavigationMode NavigationMode { get; };
     }
     
     // This is a "leaf" of the UI. This is something that can be "done" by the user.


### PR DESCRIPTION
As discussed in #273.

This will allow extensions that want to navigate around the page stack more control.

For example, the Obsidian Notes extension will want to start with a form for "Set up vault path". When they submit, instead of just going home, they'll want to GoToPage('com.obsidian.notes', mode=GoHome), so that submitting the form takes them to the notes list, rather than just _home_.

Doesn't actually implement this, of course. Just gets the API ready for it.

