### PR TITLE
Add `??` alias to TRA for web search plugin

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
@@ -50,5 +50,6 @@ public partial class AliasManager : ObservableObject
         this.AddAlias(new CommandAlias("=", "com.microsoft.cmdpal.calculator", true));
         this.AddAlias(new CommandAlias(">", "com.microsoft.cmdpal.shell", true));
         this.AddAlias(new CommandAlias("<", "com.microsoft.cmdpal.windowwalker", true));
+        this.AddAlias(new CommandAlias("??", "com.microsoft.cmdpal.websearch", true));
     }
 }


### PR DESCRIPTION
The alias was only ever added into the proof-of-concept project, which nobody ever uses anymore, whoops. We're on to bigger and better things of course... TRA!

This PR simply adds `??` as an alias for the web search plugin for self-hosting in TRA.
