### PR TITLE
Add an Icon ViewModel, to cache data locally

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -54,7 +54,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
         : base(errorContext)
     {
         _commandItemModel = item;
-        Icon = new(null, errorContext);
+        Icon = new(null);
     }
 
     //// Called from ListViewModel on background thread started in ListPage.xaml.cs
@@ -83,7 +83,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
 
         var listIcon = model.Icon;
         var iconInfo = listIcon ?? Command.Unsafe!.Icon;
-        Icon = new(iconInfo, PageContext);
+        Icon = new(iconInfo);
         Icon.InitializeProperties();
 
         var more = model.MoreCommands;
@@ -133,7 +133,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
             Title = "Error";
             Subtitle = "Item failed to load";
             MoreCommands = [];
-            Icon = new(new("❌"), PageContext); // new("❌");
+            Icon = new(new("❌")); // new("❌");
             Icon.InitializeProperties();
         }
 
@@ -174,7 +174,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
             case nameof(Icon):
                 var listIcon = model.Icon;
                 var iconInfo = listIcon != null ? listIcon : Command.Unsafe!.Icon;
-                Icon = new(iconInfo, PageContext);
+                Icon = new(iconInfo);
                 Icon.InitializeProperties();
                 break;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -25,7 +25,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
 
     public string Subtitle { get; private set; } = string.Empty;
 
-    public IconInfo Icon { get; private set; } = new(string.Empty);
+    public IconInfoViewModel Icon { get; private set; }// = new(string.Empty);
 
     public ExtensionObject<ICommand> Command { get; private set; } = new(null);
 
@@ -54,6 +54,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
         : base(errorContext)
     {
         _commandItemModel = item;
+        Icon = new(null, errorContext);
     }
 
     //// Called from ListViewModel on background thread started in ListPage.xaml.cs
@@ -81,7 +82,9 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
         Subtitle = model.Subtitle;
 
         var listIcon = model.Icon;
-        Icon = listIcon ?? Command.Unsafe!.Icon;
+        var iconInfo = listIcon ?? Command.Unsafe!.Icon;
+        Icon = new(iconInfo, PageContext);
+        Icon.InitializeProperties();
 
         var more = model.MoreCommands;
         if (more != null)
@@ -130,7 +133,8 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
             Title = "Error";
             Subtitle = "Item failed to load";
             MoreCommands = [];
-            Icon = new("❌");
+            Icon = new(new("❌"), PageContext); // new("❌");
+            Icon.InitializeProperties();
         }
 
         return false;
@@ -169,7 +173,9 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
                 break;
             case nameof(Icon):
                 var listIcon = model.Icon;
-                Icon = listIcon != null ? listIcon : Command.Unsafe!.Icon;
+                var iconInfo = listIcon != null ? listIcon : Command.Unsafe!.Icon;
+                Icon = new(iconInfo, PageContext);
+                Icon.InitializeProperties();
                 break;
 
                 // TODO! MoreCommands array, which needs to also raise HasMoreCommands

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
@@ -28,7 +28,7 @@ public sealed class CommandProviderWrapper
 
     public string DisplayName { get; private set; } = string.Empty;
 
-    public IconInfo Icon { get; private set; } = new(string.Empty);
+    public IconInfoViewModel Icon { get; private set; } = new(null);
 
     public string ProviderId => $"{extensionWrapper?.PackageFamilyName ?? string.Empty}/{Id}";
 
@@ -42,7 +42,8 @@ public sealed class CommandProviderWrapper
         isValid = true;
         Id = provider.Id;
         DisplayName = provider.DisplayName;
-        Icon = provider.Icon;
+        Icon = new(provider.Icon);
+        Icon.InitializeProperties();
     }
 
     public CommandProviderWrapper(IExtensionWrapper extension)
@@ -89,7 +90,8 @@ public sealed class CommandProviderWrapper
 
         Id = _commandProvider.Id;
         DisplayName = _commandProvider.DisplayName;
-        Icon = _commandProvider.Icon;
+        Icon = new(_commandProvider.Icon);
+        Icon.InitializeProperties();
 
         if (commands != null)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
@@ -13,7 +13,7 @@ public partial class DetailsViewModel(IDetails _details, IPageContext context) :
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
-    public IconInfo HeroImage { get; private set; } = new(string.Empty);
+    public IconInfoViewModel HeroImage { get; private set; } = new(null, context);
 
     // TODO: Metadata is an array of IDetailsElement,
     // where IDetailsElement = {IDetailsTags, IDetailsLink, IDetailsSeparator}
@@ -31,7 +31,8 @@ public partial class DetailsViewModel(IDetails _details, IPageContext context) :
 
         Title = model.Title ?? string.Empty;
         Body = model.Body ?? string.Empty;
-        HeroImage = model.HeroImage;
+        HeroImage = new(model.HeroImage, PageContext);
+        HeroImage.InitializeProperties();
 
         UpdateProperty(nameof(Title));
         UpdateProperty(nameof(Body));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
@@ -13,7 +13,7 @@ public partial class DetailsViewModel(IDetails _details, IPageContext context) :
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
-    public IconInfoViewModel HeroImage { get; private set; } = new(null, context);
+    public IconInfoViewModel HeroImage { get; private set; } = new(null);
 
     // TODO: Metadata is an array of IDetailsElement,
     // where IDetailsElement = {IDetailsTags, IDetailsLink, IDetailsSeparator}
@@ -31,7 +31,7 @@ public partial class DetailsViewModel(IDetails _details, IPageContext context) :
 
         Title = model.Title ?? string.Empty;
         Body = model.Body ?? string.Empty;
-        HeroImage = new(model.HeroImage, PageContext);
+        HeroImage = new(model.HeroImage);
         HeroImage.InitializeProperties();
 
         UpdateProperty(nameof(Title));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconDataViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconDataViewModel.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CmdPal.Extensions;
-using Microsoft.CmdPal.Extensions.Helpers;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Windows.Storage.Streams;
 
@@ -12,6 +11,11 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public partial class IconDataViewModel : ExtensionObjectViewModel
 {
     private readonly ExtensionObject<IconData> _model = new(null);
+
+    // If the extension previously gave us a Data, then died, the data will
+    // throw if we actually try to read it, but the pointer itself won't be
+    // null, so this is relatively safe.
+    public bool HasIcon => !string.IsNullOrEmpty(Icon) || Data.Unsafe != null;
 
     // Locally cached properties from IconData.
     public string Icon { get; private set; } = string.Empty;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconDataViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconDataViewModel.cs
@@ -21,7 +21,7 @@ public partial class IconDataViewModel : ObservableObject
     // Locally cached properties from IconData.
     public string Icon { get; private set; } = string.Empty;
 
-    // Streams are not trivially copyable, so we can't copy the data locally
+    // Streams are not trivially copy-able, so we can't copy the data locally
     // first. Hence why we're sticking this into an ExtensionObject
     public ExtensionObject<IRandomAccessStreamReference> Data { get; private set; } = new(null);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconDataViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconDataViewModel.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Windows.Storage.Streams;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class IconDataViewModel : ExtensionObjectViewModel
+{
+    private readonly ExtensionObject<IconData> _model = new(null);
+
+    // Locally cached properties from IconData.
+    public string Icon { get; private set; } = string.Empty;
+
+    // Streams are not trivially copyable, so we can't copy the data locally
+    // first. Hence why we're sticking this into an ExtensionObject
+    public ExtensionObject<IRandomAccessStreamReference> Data { get; private set; } = new(null);
+
+    public IconDataViewModel(IconData? icon, IPageContext errorContext)
+        : base(errorContext)
+    {
+        _model = new(icon);
+    }
+
+    // Unsafe, needs to be called on BG thread
+    public override void InitializeProperties()
+    {
+        var model = _model.Unsafe;
+        if (model == null)
+        {
+            return;
+        }
+
+        Icon = model.Icon;
+        Data = new(model.Data);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconDataViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconDataViewModel.cs
@@ -2,13 +2,14 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Windows.Storage.Streams;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public partial class IconDataViewModel : ExtensionObjectViewModel
+public partial class IconDataViewModel : ObservableObject
 {
     private readonly ExtensionObject<IconData> _model = new(null);
 
@@ -24,14 +25,13 @@ public partial class IconDataViewModel : ExtensionObjectViewModel
     // first. Hence why we're sticking this into an ExtensionObject
     public ExtensionObject<IRandomAccessStreamReference> Data { get; private set; } = new(null);
 
-    public IconDataViewModel(IconData? icon, IPageContext errorContext)
-        : base(errorContext)
+    public IconDataViewModel(IconData? icon)
     {
         _model = new(icon);
     }
 
     // Unsafe, needs to be called on BG thread
-    public override void InitializeProperties()
+    public void InitializeProperties()
     {
         var model = _model.Unsafe;
         if (model == null)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconInfoViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconInfoViewModel.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CmdPal.Extensions;
-using Microsoft.CmdPal.Extensions.Helpers;
 using Microsoft.CmdPal.UI.ViewModels.Models;
-using Windows.Storage.Streams;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
@@ -22,6 +20,10 @@ public partial class IconInfoViewModel : ExtensionObjectViewModel
     public IconDataViewModel Light { get; private set; }
 
     public IconDataViewModel Dark { get; private set; }
+
+    public IconDataViewModel IconForTheme(bool light) => Light = light ? Light : Dark;
+
+    public bool HasIcon(bool light) => IconForTheme(light).HasIcon;
 
     public IconInfoViewModel(IconInfo? icon, IPageContext errorContext)
         : base(errorContext)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconInfoViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconInfoViewModel.cs
@@ -2,12 +2,13 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public partial class IconInfoViewModel : ExtensionObjectViewModel
+public partial class IconInfoViewModel : ObservableObject
 {
     private readonly ExtensionObject<IconInfo> _model = new(null);
 
@@ -25,16 +26,15 @@ public partial class IconInfoViewModel : ExtensionObjectViewModel
 
     public bool HasIcon(bool light) => IconForTheme(light).HasIcon;
 
-    public IconInfoViewModel(IconInfo? icon, IPageContext errorContext)
-        : base(errorContext)
+    public IconInfoViewModel(IconInfo? icon)
     {
         _model = new(icon);
-        Light = new(null, errorContext);
-        Dark = new(null, errorContext);
+        Light = new(null);
+        Dark = new(null);
     }
 
     // Unsafe, needs to be called on BG thread
-    public override void InitializeProperties()
+    public void InitializeProperties()
     {
         var model = _model.Unsafe;
         if (model == null)
@@ -42,10 +42,10 @@ public partial class IconInfoViewModel : ExtensionObjectViewModel
             return;
         }
 
-        Light = new(model.Light, this.PageContext);
+        Light = new(model.Light);
         Light.InitializeProperties();
 
-        Dark = new(model.Dark, this.PageContext);
+        Dark = new(model.Dark);
         Dark.InitializeProperties();
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconInfoViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IconInfoViewModel.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Windows.Storage.Streams;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class IconInfoViewModel : ExtensionObjectViewModel
+{
+    private readonly ExtensionObject<IconInfo> _model = new(null);
+
+    // These are properties that are "observable" from the extension object
+    // itself, in the sense that they get raised by PropChanged events from the
+    // extension. However, we don't want to actually make them
+    // [ObservableProperty]s, because PropChanged comes in off the UI thread,
+    // and ObservableProperty is not smart enough to raise the PropertyChanged
+    // on the UI thread.
+    public IconDataViewModel Light { get; private set; }
+
+    public IconDataViewModel Dark { get; private set; }
+
+    public IconInfoViewModel(IconInfo? icon, IPageContext errorContext)
+        : base(errorContext)
+    {
+        _model = new(icon);
+        Light = new(null, errorContext);
+        Dark = new(null, errorContext);
+    }
+
+    // Unsafe, needs to be called on BG thread
+    public override void InitializeProperties()
+    {
+        var model = _model.Unsafe;
+        if (model == null)
+        {
+            return;
+        }
+
+        Light = new(model.Light, this.PageContext);
+        Light.InitializeProperties();
+
+        Dark = new(model.Dark, this.PageContext);
+        Dark.InitializeProperties();
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
@@ -45,7 +45,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
     // `IsLoading` property as a combo of this value and `IsInitialized`
     public bool ModelIsLoading { get; protected set; } = true;
 
-    public IconInfo Icon { get; protected set; } = new(string.Empty);
+    public IconInfoViewModel Icon { get; protected set; }
 
     public PageViewModel(IPage? model, TaskScheduler scheduler)
         : base(null)
@@ -53,6 +53,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
         _pageModel = new(model);
         Scheduler = scheduler;
         PageContext = this;
+        Icon = new(null, PageContext);
     }
 
     //// Run on background thread from ListPage.xaml.cs
@@ -98,7 +99,8 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
         Name = page.Name;
         ModelIsLoading = page.IsLoading;
         Title = page.Title;
-        Icon = page.Icon;
+        Icon = new(page.Icon, PageContext);
+        Icon.InitializeProperties();
 
         // Let the UI know about our initial properties too.
         UpdateProperty(nameof(Name));
@@ -153,7 +155,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
                 UpdateProperty(nameof(ModelIsLoading));
                 break;
             case nameof(Icon):
-                this.Icon = model.Icon;
+                this.Icon = new(model.Icon, PageContext);
                 break;
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
@@ -53,7 +53,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
         _pageModel = new(model);
         Scheduler = scheduler;
         PageContext = this;
-        Icon = new(null, PageContext);
+        Icon = new(null);
     }
 
     //// Run on background thread from ListPage.xaml.cs
@@ -99,7 +99,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
         Name = page.Name;
         ModelIsLoading = page.IsLoading;
         Title = page.Title;
-        Icon = new(page.Icon, PageContext);
+        Icon = new(page.Icon);
         Icon.InitializeProperties();
 
         // Let the UI know about our initial properties too.
@@ -155,7 +155,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
                 UpdateProperty(nameof(ModelIsLoading));
                 break;
             case nameof(Icon):
-                this.Icon = new(model.Icon, PageContext);
+                this.Icon = new(model.Icon);
                 break;
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.Mvvm.ComponentModel;
-using Microsoft.CmdPal.Extensions;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
@@ -13,7 +12,7 @@ public partial class ProviderSettingsViewModel(CommandProviderWrapper _provider,
 
     public string ExtensionName => _provider.Extension?.ExtensionDisplayName ?? "Built-in";
 
-    public IconInfo Icon => _provider.Icon;
+    public IconInfoViewModel Icon => _provider.Icon;
 
     public bool IsEnabled
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -31,7 +31,7 @@ public partial class SettingsViewModel : PageViewModel
         _settings = settings;
         _serviceProvider = serviceProvider;
 
-        Icon = new("\uE713");
+        Icon = new(new("\uE713"), PageContext);
         IsInitialized = true;
         ModelIsLoading = false;
         Title = "Settings";

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -31,7 +31,8 @@ public partial class SettingsViewModel : PageViewModel
         _settings = settings;
         _serviceProvider = serviceProvider;
 
-        Icon = new(new("\uE713"), PageContext);
+        Icon = new(new("\uE713"));
+        Icon.InitializeProperties();
         IsInitialized = true;
         ModelIsLoading = false;
         Title = "Settings";

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TagViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TagViewModel.cs
@@ -21,10 +21,10 @@ public partial class TagViewModel(ITag _tag, IPageContext context) : ExtensionOb
 
     public OptionalColor Background { get; private set; }
 
-    public IconInfo Icon { get; private set; } = new(string.Empty);
+    public IconInfoViewModel Icon { get; private set; } = new(null, context);
 
     // TODO Terrible. When we redo the icons in tags, make this something the view exposes
-    public bool HasIcon => !string.IsNullOrEmpty(Icon.Light.Icon);
+    public bool HasIcon => Icon.HasIcon(true);
 
     public ExtensionObject<ICommand> Command { get; private set; } = new(null);
 
@@ -41,7 +41,8 @@ public partial class TagViewModel(ITag _tag, IPageContext context) : ExtensionOb
         Foreground = model.Foreground;
         Background = model.Background;
         Tooltip = model.ToolTip;
-        Icon = model.Icon;
+        Icon = new(model.Icon, PageContext);
+        Icon.InitializeProperties();
 
         UpdateProperty(nameof(Text));
         UpdateProperty(nameof(Foreground));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TagViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TagViewModel.cs
@@ -21,7 +21,7 @@ public partial class TagViewModel(ITag _tag, IPageContext context) : ExtensionOb
 
     public OptionalColor Background { get; private set; }
 
-    public IconInfoViewModel Icon { get; private set; } = new(null, context);
+    public IconInfoViewModel Icon { get; private set; } = new(null);
 
     // TODO Terrible. When we redo the icons in tags, make this something the view exposes
     public bool HasIcon => Icon.HasIcon(true);
@@ -41,7 +41,7 @@ public partial class TagViewModel(ITag _tag, IPageContext context) : ExtensionOb
         Foreground = model.Foreground;
         Background = model.Background;
         Tooltip = model.ToolTip;
-        Icon = new(model.Icon, PageContext);
+        Icon = new(model.Icon);
         Icon.InitializeProperties();
 
         UpdateProperty(nameof(Text));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -111,12 +111,12 @@ public partial class IconBox : ContentControl
                         // Segoe icons, then let's give the icon some extra space
                         @this.Padding = new Thickness(0);
 
-                        IconData? iconData = null;
-                        if (eventArgs.Key is IconData)
+                        IconDataViewModel? iconData = null;
+                        if (eventArgs.Key is IconDataViewModel)
                         {
-                            iconData = eventArgs.Key as IconData;
+                            iconData = eventArgs.Key as IconDataViewModel;
                         }
-                        else if (eventArgs.Key is IconInfo info)
+                        else if (eventArgs.Key is IconInfoViewModel info)
                         {
                             iconData = requestedTheme == ElementTheme.Light ? info.Light : info.Dark;
                         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/IconCacheService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/IconCacheService.cs
@@ -2,7 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CmdPal.Extensions;
+using System.Diagnostics;
+using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.Terminal.UI;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Controls;
@@ -13,12 +14,12 @@ namespace Microsoft.CmdPal.UI.ExtViews;
 
 public sealed class IconCacheService(DispatcherQueue dispatcherQueue)
 {
-    public Task<IconSource?> GetIconSource(IconData icon) =>
+    public Task<IconSource?> GetIconSource(IconDataViewModel icon) =>
 
         // todo: actually implement a cache of some sort
         IconToSource(icon);
 
-    private async Task<IconSource?> IconToSource(IconData icon)
+    private async Task<IconSource?> IconToSource(IconDataViewModel icon)
     {
         // bodgy: apparently IconData, despite being a struct, doesn't get
         // MarshalByValue'd into our process. What's even the point then?
@@ -32,7 +33,14 @@ public sealed class IconCacheService(DispatcherQueue dispatcherQueue)
             }
             else if (icon.Data != null)
             {
-                return await StreamToIconSource(icon.Data);
+                try
+                {
+                    return await StreamToIconSource(icon.Data.Unsafe!);
+                }
+                catch
+                {
+                    Debug.WriteLine("Failed to load icon from stream");
+                }
             }
         }
         catch

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/IconCacheProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/IconCacheProvider.cs
@@ -2,9 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.UI.Controls;
 using Microsoft.CmdPal.UI.ExtViews;
+using Microsoft.CmdPal.UI.ViewModels;
 
 namespace Microsoft.CmdPal.UI.Helpers;
 
@@ -24,7 +24,7 @@ public static partial class IconCacheProvider
             return;
         }
 
-        if (args.Key is IconData iconData)
+        if (args.Key is IconDataViewModel iconData)
         {
             var deferral = args.GetDeferral();
 
@@ -32,7 +32,7 @@ public static partial class IconCacheProvider
 
             deferral.Complete();
         }
-        else if (args.Key is IconInfo iconInfo)
+        else if (args.Key is IconInfoViewModel iconInfo)
         {
             var deferral = args.GetDeferral();
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml.cs
@@ -303,18 +303,8 @@ public sealed partial class ShellPage :
         get
         {
             var requestedTheme = ActualTheme;
-            var iconInfo = ViewModel.Details?.HeroImage;
-            var data = requestedTheme == Microsoft.UI.Xaml.ElementTheme.Dark ?
-                iconInfo?.Dark :
-                iconInfo?.Light;
-
-            // We have an icon, AND EITHER:
-            //      We have a string icon, OR
-            //      we have a data blob
-            var hasIcon = (data != null) &&
-                    (!string.IsNullOrEmpty(data.Icon) ||
-                    data.Data != null);
-            return hasIcon;
+            var iconInfoVM = ViewModel.Details?.HeroImage;
+            return iconInfoVM?.HasIcon(requestedTheme == Microsoft.UI.Xaml.ElementTheme.Light) ?? false;
         }
     }
 }


### PR DESCRIPTION
(targets #308, which targets #299)

`IconData` and `IconInfo` are unfortunately, not trivially marshallable into the host process. This creates a collection of cases where an app can crash and take the host down, because we'll try to inquire something about the icon. 

It broke reloading when an extension crashed. 
It broke backing out of a crashed extension. 


Previously: #218 
Closes #235 
