### PR TITLE
Fix the icons on Window Walker

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Commands/SwitchToWindowCommand.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Commands/SwitchToWindowCommand.cs
@@ -17,7 +17,6 @@ internal sealed partial class SwitchToWindowCommand : InvokableCommand
     public SwitchToWindowCommand(Window? window)
     {
         Name = Resources.switch_to_command_title;
-        Icon = new(string.Empty);
         _window = window;
         if (_window != null)
         {
@@ -26,7 +25,8 @@ internal sealed partial class SwitchToWindowCommand : InvokableCommand
             {
                 try
                 {
-                    Icon = new(p.MainModule?.FileName);
+                    var processFileName = p.MainModule?.FileName;
+                    Icon = new(processFileName);
                 }
                 catch
                 {

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Components/ResultHelper.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Components/ResultHelper.cs
@@ -22,7 +22,7 @@ internal static class ResultHelper
     /// <param name="searchControllerResults">List with all search controller matches</param>
     /// <param name="icon">The path to the result icon</param>
     /// <returns>List of results</returns>
-    internal static List<WindowWalkerListItem> GetResultList(List<SearchResult> searchControllerResults, bool isKeywordSearch, string icon, string infoIcon)
+    internal static List<WindowWalkerListItem> GetResultList(List<SearchResult> searchControllerResults, bool isKeywordSearch, string infoIcon)
     {
         if (searchControllerResults == null || searchControllerResults.Count == 0)
         {
@@ -38,7 +38,7 @@ internal static class ResultHelper
         // Using parallel processing if the operation is CPU-bound and the list is large.
         resultsList = searchControllerResults
             .AsParallel()
-            .Select(x => CreateResultFromSearchResult(x, icon))
+            .Select(x => CreateResultFromSearchResult(x))
             .ToList();
 
         if (addExplorerInfo && !SettingsManager.Instance.HideExplorerSettingInfo)
@@ -55,12 +55,11 @@ internal static class ResultHelper
     /// <param name="searchResult">The SearchResult object to convert.</param>
     /// <param name="icon">The path to the icon that should be used for the Result.</param>
     /// <returns>A Result object populated with data from the SearchResult.</returns>
-    private static WindowWalkerListItem CreateResultFromSearchResult(SearchResult searchResult, string icon)
+    private static WindowWalkerListItem CreateResultFromSearchResult(SearchResult searchResult)
     {
         var item = new WindowWalkerListItem(searchResult.Result)
         {
             Title = searchResult.Result.Title,
-            Icon = new(icon),
             Subtitle = GetSubtitle(searchResult.Result),
             Tags = GetTags(searchResult.Result),
         };

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Pages/WindowWalkerListPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowWalker/Pages/WindowWalkerListPage.cs
@@ -40,7 +40,7 @@ internal sealed partial class WindowWalkerListPage : DynamicListPage, IDisposabl
         SearchController.Instance.UpdateSearchText(query);
         var searchControllerResults = SearchController.Instance.SearchMatches;
 
-        return ResultHelper.GetResultList(searchControllerResults, !string.IsNullOrEmpty(query), string.Empty, "\uE946");
+        return ResultHelper.GetResultList(searchControllerResults, !string.IsNullOrEmpty(query), "\uE946");
     }
 
     public override IListItem[] GetItems() => Query(SearchText).ToArray();


### PR DESCRIPTION
The ListItems were having their icons manually initialized to `icon`, which was always passed as `string.Empty`.

I suspect this is vestigial from PT Run - where the icon would be paseed in based on the theme. This prevented us from being able to fall back to the icon from the command, which is where we stuck the actual icon
