### PR TITLE
Fix the Web Search Fallback Command

### DIFF
--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Text;
 using Microsoft.CmdPal.Ext.WebSearch.Helpers;
 using Microsoft.CmdPal.Extensions.Helpers;
-using Wox.Plugin;
 using BrowserInfo = Wox.Plugin.Common.DefaultBrowserInfo;
 
 namespace Microsoft.CmdPal.Ext.WebSearch.Commands;

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Text;
 using Microsoft.CmdPal.Ext.WebSearch.Helpers;
 using Microsoft.CmdPal.Extensions.Helpers;
+using Wox.Plugin;
 using BrowserInfo = Wox.Plugin.Common.DefaultBrowserInfo;
 
 namespace Microsoft.CmdPal.Ext.WebSearch.Commands;
@@ -20,6 +21,7 @@ internal sealed partial class FallbackExecuteSearchItem : FallbackCommandItem
     {
         _executeItem = (SearchWebCommand)this.Command!;
         Title = string.Empty;
+        _executeItem.Name = string.Empty;
         Subtitle = string.Format(CultureInfo.CurrentCulture, PluginOpen, BrowserInfo.Name ?? BrowserInfo.MSEdgeName);
         Icon = new("\uF6FA"); // WebSearch icon
     }
@@ -27,6 +29,7 @@ internal sealed partial class FallbackExecuteSearchItem : FallbackCommandItem
     public override void UpdateQuery(string query)
     {
         _executeItem.Arguments = query;
-        Title = string.IsNullOrEmpty(query) ? string.Empty : query;
+        _executeItem.Name = string.IsNullOrEmpty(query) ? string.Empty : Properties.Resources.open_in_default_browser;
+        Title = query;
     }
 }


### PR DESCRIPTION
The fallback command was still showing up on empty query because we weren't explicitly setting the underlying command name to the empty string when it is empty. This is what it looked like in the root view: 

![image](https://github.com/user-attachments/assets/eff8249f-8acb-47ef-9529-86ebb7011811)

This is a really small PR that just fixes that issue.