### PR TITLE
Add 3 settings for Clint

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/FocusSearchBoxMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/FocusSearchBoxMessage.cs
@@ -4,6 +4,6 @@
 
 namespace Microsoft.CmdPal.UI.ViewModels.Messages;
 
-public record NavigateBackMessage(bool FromBackspace = false)
+public record FocusSearchBoxMessage()
 {
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -28,6 +28,12 @@ public partial class SettingsModel : ObservableObject
 
     public bool HotkeyGoesHome { get; set; }
 
+    public bool BackspaceGoesBack { get; set; }
+
+    public bool SingleClickActivates { get; set; }
+
+    public bool HighlightSearchOnActivate { get; set; } = true;
+
     public Dictionary<string, ProviderSettings> ProviderSettings { get; set; } = [];
 
     // END SETTINGS

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -43,6 +43,36 @@ public partial class SettingsViewModel : PageViewModel
         }
     }
 
+    public bool BackspaceGoesBack
+    {
+        get => _settings.BackspaceGoesBack;
+        set
+        {
+            _settings.BackspaceGoesBack = value;
+            Save();
+        }
+    }
+
+    public bool SingleClickActivates
+    {
+        get => _settings.SingleClickActivates;
+        set
+        {
+            _settings.SingleClickActivates = value;
+            Save();
+        }
+    }
+
+    public bool HighlightSearchOnActivate
+    {
+        get => _settings.HighlightSearchOnActivate;
+        set
+        {
+            _settings.HighlightSearchOnActivate = value;
+            Save();
+        }
+    }
+
     public ObservableCollection<ProviderSettingsViewModel> CommandProviders { get; } = [];
 
     public SettingsViewModel(SettingsModel settings, IServiceProvider serviceProvider, TaskScheduler scheduler)
@@ -87,8 +117,5 @@ public partial class SettingsViewModel : PageViewModel
         return allProviders;
     }
 
-    private void Save()
-    {
-        SettingsModel.SaveSettings(_settings);
-    }
+    private void Save() => SettingsModel.SaveSettings(_settings);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListDetailPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListDetailPage.xaml.cs
@@ -32,6 +32,6 @@ public sealed partial class ListDetailPage : Page
 
     private void Button_Click(object sender, RoutedEventArgs e)
     {
-        WeakReferenceMessenger.Default.Send<NavigateBackMessage>();
+        WeakReferenceMessenger.Default.Send<NavigateBackMessage>(new());
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -45,7 +45,7 @@
         <DataTemplate x:Key="ListItemViewModelTemplate" x:DataType="viewmodels:ListItemViewModel">
 
             <!--  TODO: collapse item if it's empty  -->
-            <ListViewItem>
+            <ListViewItem IsDoubleTapEnabled="True" DoubleTapped="ListViewItem_DoubleTapped">
                 <Grid Padding="0,12,0,12" ColumnSpacing="12">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="28" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -129,8 +129,8 @@ public sealed partial class ListPage : Page,
 
     private void ListViewItem_DoubleTapped(object sender, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs e)
     {
-        if (sender is ListViewItem lvi &&
-            this.ItemsList.ItemFromContainer(lvi) is ListItemViewModel vm)
+        if (sender is ListViewItem viewItem &&
+            this.ItemsList.ItemFromContainer(viewItem) is ListItemViewModel vm)
         {
             var settings = App.Current.Services.GetService<SettingsModel>()!;
             if (!settings.SingleClickActivates)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -4,9 +4,9 @@
 
 using System.Diagnostics;
 using CommunityToolkit.Mvvm.Messaging;
-using CommunityToolkit.WinUI;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
@@ -76,13 +76,18 @@ public sealed partial class ListPage : Page,
     [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "VS is too aggressive at pruning methods bound in XAML")]
     private void ListView_ItemClick(object sender, ItemClickEventArgs e)
     {
-        if (e.ClickedItem is ListItemViewModel item && item == ItemsList.SelectedItem)
+        if (e.ClickedItem is ListItemViewModel item)
         {
-            ViewModel?.InvokeItemCommand.Execute(item);
-        }
-        else if (e.ClickedItem is ListItemViewModel item2)
-        {
-            ViewModel?.UpdateSelectedItemCommand.Execute(item2);
+            var settings = App.Current.Services.GetService<SettingsModel>()!;
+            if (settings.SingleClickActivates)
+            {
+                ViewModel?.InvokeItemCommand.Execute(item);
+            }
+            else
+            {
+                ViewModel?.UpdateSelectedItemCommand.Execute(item);
+                WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
+            }
         }
     }
 
@@ -119,6 +124,19 @@ public sealed partial class ListPage : Page,
         if (ItemsList.SelectedItem != null)
         {
             ItemsList.ScrollIntoView(ItemsList.SelectedItem);
+        }
+    }
+
+    private void ListViewItem_DoubleTapped(object sender, Microsoft.UI.Xaml.Input.DoubleTappedRoutedEventArgs e)
+    {
+        if (sender is ListViewItem lvi &&
+            this.ItemsList.ItemFromContainer(lvi) is ListItemViewModel vm)
+        {
+            var settings = App.Current.Services.GetService<SettingsModel>()!;
+            if (!settings.SingleClickActivates)
+            {
+                ViewModel?.InvokeItemCommand.Execute(vm);
+            }
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/SettingsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/SettingsPage.xaml
@@ -72,15 +72,35 @@
                             HeaderIcon="{ui:FontIcon Glyph=&#xE80F;}">
                             <ToggleSwitch IsOn="{x:Bind ViewModel.HotkeyGoesHome, Mode=TwoWay}" />
                         </controls:SettingsCard>
+                        <controls:SettingsCard
+                            Description="When enabled, the previous search text will be selected when the app is opened"
+                            Header="Highlight search on activate">
+                            <ToggleSwitch IsOn="{x:Bind ViewModel.HighlightSearchOnActivate, Mode=TwoWay}" />
+                        </controls:SettingsCard>
                     </controls:SettingsExpander.Items>
                 </controls:SettingsExpander>
-
+                
                 <controls:SettingsCard
                     Description="Controls if app details are automatically expanded or not"
                     Header="Show app details"
                     HeaderIcon="{ui:FontIcon Glyph=&#xE8A0;}">
                     <ToggleSwitch IsOn="{x:Bind ViewModel.ShowAppDetails, Mode=TwoWay}" />
                 </controls:SettingsCard>
+
+                <controls:SettingsCard
+                    Description="When enabled, pressing backspace when the search text is empty will take you back"
+                    Header="Backspace goes back"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE750;}">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.BackspaceGoesBack, Mode=TwoWay}" />
+                </controls:SettingsCard>
+                
+                <controls:SettingsCard
+                    Description="When enabled, single click activates list items. When disabled, single click selects and double click activates."
+                    Header="Single-click activates"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE962;}">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.SingleClickActivates, Mode=TwoWay}" />
+                </controls:SettingsCard>
+
 
                 <TextBlock x:Uid="ExtensionSettingsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
 


### PR DESCRIPTION
Is your name Clint? Do you like settings? Did you hate that backspace on the main page could dismiss the palette? If you said yes to any of that, you're in luck! This PR is for you!

This PR adds three new settings:

* `BackspaceGoesBack`: Controls if backspace with an empty search takes you back a level
* `SingleClickActivates`: Allows users to toggle between the "single click selects, double activates" vs "single click activates" behavior
* `HighlightSearchOnActivate`: When `true` (**default**), this will select the text in the search bar when the window is summoned

This drive-by fixes a bug where clicking to select an item stole focus from the search box.

closes #306

