### PR TITLE
Add support for hiding messages too

### DIFF
--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPage.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPage.cs
@@ -30,8 +30,17 @@ internal sealed partial class SampleListPage : ListPage
                         }
                 ],
             },
-            new ListItem(new SendMessageCommand()) { Title = "I send lots of messages" },
+            new ListItem(new SendMessageCommand())
+            {
+                Title = "I send lots of messages",
+                Subtitle = "Status messages can be used to provide feedback to the user in-app",
+            },
             new SendSingleMessageItem(),
+            new ListItem(new IndeterminateProgressMessageCommand())
+            {
+                Title = "Do a thing with a spinner",
+                Subtitle = "Messages can have progress spinners, to indicate something is happening in the background",
+            },
         ];
     }
 }

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPage.cs
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/Pages/SampleListPage.cs
@@ -30,7 +30,8 @@ internal sealed partial class SampleListPage : ListPage
                         }
                 ],
             },
-            new ListItem(new SendMessageCommand()) { Title = "I send messages" },
+            new ListItem(new SendMessageCommand()) { Title = "I send lots of messages" },
+            new SendSingleMessageItem(),
         ];
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -162,6 +162,12 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
 
         switch (propertyName)
         {
+            case nameof(Command):
+                this.Command = new(model.Command);
+                Name = model.Command?.Name ?? string.Empty;
+                UpdateProperty(nameof(Name));
+
+                break;
             case nameof(Name):
                 this.Name = model.Command?.Name ?? string.Empty;
                 break;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteHost.cs
@@ -109,6 +109,22 @@ public sealed partial class CommandPaletteHost : IExtensionHost
 
     public void ProcessStatusMessage(IStatusMessage message)
     {
+        // If this message is already in the list of messages, just bring it to the top
+        var oldVm = StatusMessages.Where(messageVM => messageVM.Model.Unsafe == message).FirstOrDefault();
+        if (oldVm != null)
+        {
+            Task.Factory.StartNew(
+                () =>
+                {
+                    StatusMessages.Remove(oldVm);
+                    StatusMessages.Add(oldVm);
+                },
+                CancellationToken.None,
+                TaskCreationOptions.None,
+                _globalLogPageContext.Scheduler);
+            return;
+        }
+
         var vm = new StatusMessageViewModel(message, _globalLogPageContext);
         vm.SafeInitializePropertiesSynchronous();
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteHost.cs
@@ -18,19 +18,15 @@ public sealed partial class CommandPaletteHost : IExtensionHost
 
     private static readonly GlobalLogPageContext _globalLogPageContext = new();
 
-    private ulong _hostHwnd;
-
-    public ulong HostingHwnd => _hostHwnd;
+    public ulong HostingHwnd { get; private set; }
 
     public string LanguageOverride => string.Empty;
 
-    public static ObservableCollection<LogMessageViewModel> LogMessages { get; } = new();
+    public static ObservableCollection<LogMessageViewModel> LogMessages { get; } = [];
 
-    public ObservableCollection<StatusMessageViewModel> StatusMessages { get; } = new();
+    public ObservableCollection<StatusMessageViewModel> StatusMessages { get; } = [];
 
-    private readonly IExtensionWrapper? _source;
-
-    public IExtensionWrapper? Extension => _source;
+    public IExtensionWrapper? Extension { get; }
 
     private CommandPaletteHost()
     {
@@ -38,11 +34,16 @@ public sealed partial class CommandPaletteHost : IExtensionHost
 
     public CommandPaletteHost(IExtensionWrapper source)
     {
-        _source = source;
+        Extension = source;
     }
 
-    public IAsyncAction ShowStatus(IStatusMessage message)
+    public IAsyncAction ShowStatus(IStatusMessage? message)
     {
+        if (message == null)
+        {
+            return Task.CompletedTask.AsAsyncAction();
+        }
+
         Debug.WriteLine(message.Message);
 
         _ = Task.Run(() =>
@@ -53,13 +54,27 @@ public sealed partial class CommandPaletteHost : IExtensionHost
         return Task.CompletedTask.AsAsyncAction();
     }
 
-    public IAsyncAction HideStatus(IStatusMessage message)
+    public IAsyncAction HideStatus(IStatusMessage? message)
     {
+        if (message == null)
+        {
+            return Task.CompletedTask.AsAsyncAction();
+        }
+
+        _ = Task.Run(() =>
+        {
+            ProcessHideStatusMessage(message);
+        });
         return Task.CompletedTask.AsAsyncAction();
     }
 
-    public IAsyncAction LogMessage(ILogMessage message)
+    public IAsyncAction LogMessage(ILogMessage? message)
     {
+        if (message == null)
+        {
+            return Task.CompletedTask.AsAsyncAction();
+        }
+
         Debug.WriteLine(message.Message);
 
         _ = Task.Run(() =>
@@ -77,9 +92,9 @@ public sealed partial class CommandPaletteHost : IExtensionHost
         var vm = new LogMessageViewModel(message, _globalLogPageContext);
         vm.SafeInitializePropertiesSynchronous();
 
-        if (_source != null)
+        if (Extension != null)
         {
-            vm.ExtensionPfn = _source.PackageFamilyName;
+            vm.ExtensionPfn = Extension.PackageFamilyName;
         }
 
         Task.Factory.StartNew(
@@ -97,9 +112,9 @@ public sealed partial class CommandPaletteHost : IExtensionHost
         var vm = new StatusMessageViewModel(message, _globalLogPageContext);
         vm.SafeInitializePropertiesSynchronous();
 
-        if (_source != null)
+        if (Extension != null)
         {
-            vm.ExtensionPfn = _source.PackageFamilyName;
+            vm.ExtensionPfn = Extension.PackageFamilyName;
         }
 
         Task.Factory.StartNew(
@@ -112,8 +127,27 @@ public sealed partial class CommandPaletteHost : IExtensionHost
             _globalLogPageContext.Scheduler);
     }
 
-    public void SetHostHwnd(ulong hostHwnd)
+    public void ProcessHideStatusMessage(IStatusMessage message)
     {
-        _hostHwnd = hostHwnd;
+        Task.Factory.StartNew(
+            () =>
+            {
+                try
+                {
+                    var vm = StatusMessages.Where(messageVM => messageVM.Model.Unsafe == message).FirstOrDefault();
+                    if (vm != null)
+                    {
+                        StatusMessages.Remove(vm);
+                    }
+                }
+                catch
+                {
+                }
+            },
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            _globalLogPageContext.Scheduler);
     }
+
+    public void SetHostHwnd(ulong hostHwnd) => HostingHwnd = hostHwnd;
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProgressViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProgressViewModel.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class ProgressViewModel : ExtensionObjectViewModel
+{
+    public ExtensionObject<IProgressState> Model { get; }
+
+    public bool IsIndeterminate { get; private set; }
+
+    public uint ProgressPercent { get; private set; }
+
+    public double ProgressValue => ProgressPercent / 100.0;
+
+    public ProgressViewModel(IProgressState progress, IPageContext context)
+        : base(context)
+    {
+        Model = new(progress);
+    }
+
+    public override void InitializeProperties()
+    {
+        var model = Model.Unsafe;
+        if (model == null)
+        {
+            return; // throw?
+        }
+
+        IsIndeterminate = model.IsIndeterminate;
+        ProgressPercent = model.ProgressPercent;
+
+        model.PropChanged += Model_PropChanged;
+    }
+
+    private void Model_PropChanged(object sender, PropChangedEventArgs args)
+    {
+        try
+        {
+            FetchProperty(args.PropertyName);
+        }
+        catch (Exception ex)
+        {
+            PageContext.ShowException(ex);
+        }
+    }
+
+    protected virtual void FetchProperty(string propertyName)
+    {
+        var model = this.Model.Unsafe;
+        if (model == null)
+        {
+            return; // throw?
+        }
+
+        switch (propertyName)
+        {
+            case nameof(IsIndeterminate):
+                this.IsIndeterminate = model.IsIndeterminate;
+                break;
+            case nameof(ProgressPercent):
+                this.ProgressPercent = model.ProgressPercent;
+                UpdateProperty(nameof(ProgressValue));
+                break;
+        }
+
+        UpdateProperty(propertyName);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/StatusMessageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/StatusMessageViewModel.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 
 public partial class StatusMessageViewModel : ExtensionObjectViewModel
 {
-    private readonly ExtensionObject<IStatusMessage> _model;
+    public ExtensionObject<IStatusMessage> Model { get; }
 
     public string Message { get; private set; } = string.Empty;
 
@@ -20,12 +20,12 @@ public partial class StatusMessageViewModel : ExtensionObjectViewModel
     public StatusMessageViewModel(IStatusMessage message, IPageContext context)
         : base(context)
     {
-        _model = new(message);
+        Model = new(message);
     }
 
     public override void InitializeProperties()
     {
-        var model = _model.Unsafe;
+        var model = Model.Unsafe;
         if (model == null)
         {
             return; // throw?
@@ -51,7 +51,7 @@ public partial class StatusMessageViewModel : ExtensionObjectViewModel
 
     protected virtual void FetchProperty(string propertyName)
     {
-        var model = this._model.Unsafe;
+        var model = this.Model.Unsafe;
         if (model == null)
         {
             return; // throw?

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/StatusMessageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/StatusMessageViewModel.cs
@@ -17,6 +17,12 @@ public partial class StatusMessageViewModel : ExtensionObjectViewModel
 
     public string ExtensionPfn { get; set; } = string.Empty;
 
+    public ProgressViewModel? Progress { get; private set; }
+
+    public bool HasProgress => Progress != null;
+
+    // public bool IsIndeterminate => Progress != null && Progress.IsIndeterminate;
+    // public double ProgressValue => (Progress?.ProgressPercent ?? 0) / 100.0;
     public StatusMessageViewModel(IStatusMessage message, IPageContext context)
         : base(context)
     {
@@ -33,6 +39,13 @@ public partial class StatusMessageViewModel : ExtensionObjectViewModel
 
         Message = model.Message;
         State = model.State;
+        var modelProgress = model.Progress;
+        if (modelProgress != null)
+        {
+            Progress = new(modelProgress, this.PageContext);
+            Progress.InitializeProperties();
+            UpdateProperty(nameof(HasProgress));
+        }
 
         model.PropChanged += Model_PropChanged;
     }
@@ -64,6 +77,20 @@ public partial class StatusMessageViewModel : ExtensionObjectViewModel
                 break;
             case nameof(State):
                 this.State = model.State;
+                break;
+            case nameof(Progress):
+                var modelProgress = model.Progress;
+                if (modelProgress != null)
+                {
+                    Progress = new(modelProgress, this.PageContext);
+                    Progress.InitializeProperties();
+                }
+                else
+                {
+                    Progress = null;
+                }
+
+                UpdateProperty(nameof(HasProgress));
                 break;
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ShellPage.xaml
@@ -240,7 +240,18 @@
                 CornerRadius="{ThemeResource ControlCornerRadius}"
                 IsOpen="{x:Bind ViewModel.CurrentPage.HasStatusMessage, Mode=OneWay}"
                 Message="{x:Bind ViewModel.CurrentPage.MostRecentStatusMessage.Message, Mode=OneWay}"
-                Severity="{x:Bind ViewModel.CurrentPage.MostRecentStatusMessage.State, Mode=OneWay, Converter={StaticResource MessageStateToSeverityConverter}}" />
+                Severity="{x:Bind ViewModel.CurrentPage.MostRecentStatusMessage.State, Mode=OneWay, Converter={StaticResource MessageStateToSeverityConverter}}">
+
+                <InfoBar.Content>
+                    <ProgressBar 
+                        Visibility="{x:Bind ViewModel.CurrentPage.MostRecentStatusMessage.HasProgress, Mode=OneWay}"
+                        IsIndeterminate="{x:Bind ViewModel.CurrentPage.MostRecentStatusMessage.Progress.IsIndeterminate, Mode=OneWay}"
+                        Value="{x:Bind ViewModel.CurrentPage.MostRecentStatusMessage.Progress.ProgressValue, Mode=OneWay}"
+                        Margin="0,-20,0,0"
+                    />
+                    <!--Margin="0,0,0,6" MaxWidth="200"/>-->
+                </InfoBar.Content>
+            </InfoBar>
         </StackPanel>
 
         <cpcontrols:ActionBar Grid.Row="1" CurrentPageViewModel="{x:Bind ViewModel.CurrentPage, Mode=OneWay}" />

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ExtensionHost.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ExtensionHost.cs
@@ -6,14 +6,9 @@ namespace Microsoft.CmdPal.Extensions.Helpers;
 
 public class ExtensionHost
 {
-    private static IExtensionHost? _host;
+    public static IExtensionHost? Host { get; private set; }
 
-    public static IExtensionHost? Host => _host;
-
-    public static void Initialize(IExtensionHost host)
-    {
-        _host = host;
-    }
+    public static void Initialize(IExtensionHost host) => Host = host;
 
     /// <summary>
     /// Fire-and-forget a log message to the Command Palette host app. Since
@@ -54,6 +49,23 @@ public class ExtensionHost
                 try
                 {
                     await Host.ShowStatus(message);
+                }
+                catch (Exception)
+                {
+                }
+            });
+        }
+    }
+
+    public static void HideStatus(IStatusMessage message)
+    {
+        if (Host != null)
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Host.HideStatus(message);
                 }
                 catch (Exception)
                 {

--- a/src/modules/cmdpal/exts/SamplePagesExtension/Pages/SendMessageCommand.cs
+++ b/src/modules/cmdpal/exts/SamplePagesExtension/Pages/SendMessageCommand.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
+using Windows.Foundation;
 
 namespace SamplePagesExtension;
 
@@ -24,6 +25,50 @@ internal sealed partial class SendMessageCommand : InvokableCommand
 
         var message = new StatusMessage() { Message = $"I am status message no.{sentMessages++}", State = kind };
         ExtensionHost.ShowStatus(message);
+        return CommandResult.KeepOpen();
+    }
+}
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Sample code sometimes makes more sense in a single file")]
+internal sealed partial class SendSingleMessageItem : ListItem
+{
+    private readonly SingleMessageCommand _command;
+
+    public SendSingleMessageItem()
+        : base(new SingleMessageCommand())
+    {
+        Title = "I send a single message";
+        _command = (SingleMessageCommand)Command;
+        _command.UpdateListItem += (sender, args) =>
+        {
+            Title = _command.Shown ? "Hide message" : "I send a single message";
+        };
+    }
+}
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Sample code sometimes makes more sense in a single file")]
+internal sealed partial class SingleMessageCommand : InvokableCommand
+{
+    public event TypedEventHandler<SingleMessageCommand, object> UpdateListItem;
+
+    private readonly StatusMessage _myMessage = new() { Message = "I am a status message" };
+
+    public bool Shown { get; private set; }
+
+    public override ICommandResult Invoke()
+    {
+        if (Shown)
+        {
+            ExtensionHost.HideStatus(_myMessage);
+        }
+        else
+        {
+            ExtensionHost.ShowStatus(_myMessage);
+        }
+
+        Shown = !Shown;
+        Name = Shown ? "Hide" : "Show";
+        UpdateListItem?.Invoke(this, null);
         return CommandResult.KeepOpen();
     }
 }

--- a/src/modules/cmdpal/exts/SamplePagesExtension/Pages/SendMessageCommand.cs
+++ b/src/modules/cmdpal/exts/SamplePagesExtension/Pages/SendMessageCommand.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
 using Windows.Foundation;
@@ -38,6 +40,8 @@ internal sealed partial class SendSingleMessageItem : ListItem
         : base(new SingleMessageCommand())
     {
         Title = "I send a single message";
+        Title = "This demonstrates both showing and hiding a single message";
+
         _command = (SingleMessageCommand)Command;
         _command.UpdateListItem += (sender, args) =>
         {
@@ -69,6 +73,62 @@ internal sealed partial class SingleMessageCommand : InvokableCommand
         Shown = !Shown;
         Name = Shown ? "Hide" : "Show";
         UpdateListItem?.Invoke(this, null);
+        return CommandResult.KeepOpen();
+    }
+}
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Sample code sometimes makes more sense in a single file")]
+internal sealed partial class IndeterminateProgressMessageCommand : InvokableCommand
+{
+    private readonly StatusMessage _myMessage = new()
+    {
+        Message = "Doing the thing...",
+        Progress = new ProgressState() { IsIndeterminate = true },
+    };
+
+    private enum State
+    {
+        NotStarted,
+        Started,
+        Done,
+    }
+
+    private State _state;
+
+    public IndeterminateProgressMessageCommand()
+    {
+        this.Name = "Do the thing";
+    }
+
+    public override ICommandResult Invoke()
+    {
+        if (_state == State.NotStarted)
+        {
+            ExtensionHost.ShowStatus(_myMessage);
+            _ = Task.Run(() =>
+            {
+                Thread.Sleep(3000);
+
+                _state = State.Done;
+                _myMessage.State = MessageState.Success;
+                _myMessage.Message = "Did the thing!";
+                _myMessage.Progress = null;
+
+                Thread.Sleep(3000);
+                ExtensionHost.HideStatus(_myMessage);
+                _state = State.NotStarted;
+
+                _myMessage.State = MessageState.Info;
+                _myMessage.Message = "Doing the thing...";
+                _myMessage.Progress = new ProgressState() { IsIndeterminate = true };
+            });
+            _state = State.Started;
+        }
+        else if (_state == State.Started)
+        {
+            ExtensionHost.ShowStatus(_myMessage);
+        }
+
         return CommandResult.KeepOpen();
     }
 }


### PR DESCRIPTION
Bits of status messages that were omitted from #281. 

This lets extensions hide messages (and exposes the helper in the helper lib). 

It also adds support for displaying progress as a progress bar underneath the text of the status message. I'll need An Adult to help with the XAML, to re-template the InfoBar to allow a progress wheel in the icon instead, but for now? good enough. 

I'm doing this to unblock the next PR, which should add some rudimentary winget support.

