### PR TITLE
Add isMultiline and placeholder to Input.Text

### DIFF
--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/TextSetting.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/TextSetting.cs
@@ -9,6 +9,10 @@ namespace Microsoft.CmdPal.Extensions.Helpers;
 
 public class TextSetting : Setting<string>
 {
+    public bool Multiline { get; set; }
+
+    public string Placeholder { get; set; } = string.Empty;
+
     private TextSetting()
         : base()
     {
@@ -36,6 +40,8 @@ public class TextSetting : Setting<string>
             { "value", Value ?? string.Empty },
             { "isRequired", IsRequired },
             { "errorMessage", ErrorMessage },
+            { "isMultiline", Multiline },
+            { "placeholder", Placeholder },
         };
     }
 


### PR DESCRIPTION
Add `isMultiline` and `placeholder` to `Input.Text`.
Default is the current behavior: single line without placeholder.