### PR TITLE
Don't move the caret to the end of the input if nothing changed

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -240,10 +240,16 @@ public sealed partial class SearchBar : UserControl,
         if (CurrentPageViewModel is ListViewModel list &&
             property == nameof(ListViewModel.SearchText))
         {
-            FilterBox.Text = list.SearchText;
+            // Only if the text actually changed...
+            // (sometimes this triggers on a round-trip of the SearchText)
+            if (FilterBox.Text != list.SearchText)
+            {
+                // ... Update our displayed text, and...
+                FilterBox.Text = list.SearchText;
 
-            // Move the cursor to the end of the input
-            FilterBox.Select(FilterBox.Text.Length, 0);
+                // ... Move the cursor to the end of the input
+                FilterBox.Select(FilterBox.Text.Length, 0);
+            }
         }
     }
 


### PR DESCRIPTION
Title. 

I just noticed that if you move the caret earlier in the input, then type, we'll toss the caret to the end of the input. Ew. Don't do that.

We should only move the caret if the text actually changed from what we already had. 