### PR TITLE
Hot (un)load extensions on (un)install

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Services/IExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Services/IExtensionService.cs
@@ -24,6 +24,8 @@ public interface IExtensionService
 
     public event TypedEventHandler<IExtensionService, IEnumerable<IExtensionWrapper>>? OnExtensionAdded;
 
+    public event TypedEventHandler<IExtensionService, IEnumerable<IExtensionWrapper>>? OnExtensionRemoved;
+
     public void EnableExtension(string extensionUniqueId);
 
     public void DisableExtension(string extensionUniqueId);

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Services/IExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Services/IExtensionService.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Windows.Foundation;
 
 namespace Microsoft.CmdPal.Common.Services;
 
@@ -20,6 +21,8 @@ public interface IExtensionService
     Task SignalStopExtensionsAsync();
 
     public event EventHandler OnExtensionsChanged;
+
+    public event TypedEventHandler<IExtensionService, IEnumerable<IExtensionWrapper>>? OnExtensionAdded;
 
     public void EnableExtension(string extensionUniqueId);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Services/IExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Services/IExtensionService.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Windows.Foundation;
@@ -19,8 +18,6 @@ public interface IExtensionService
     IExtensionWrapper? GetInstalledExtension(string extensionUniqueId);
 
     Task SignalStopExtensionsAsync();
-
-    public event EventHandler OnExtensionsChanged;
 
     public event TypedEventHandler<IExtensionService, IEnumerable<IExtensionWrapper>>? OnExtensionAdded;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteHost.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using Microsoft.CmdPal.Common.Services;
 using Microsoft.CmdPal.Extensions;
+using Microsoft.CmdPal.Extensions.Helpers;
 using Windows.Foundation;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
@@ -173,4 +174,11 @@ public sealed partial class CommandPaletteHost : IExtensionHost
     }
 
     public void SetHostHwnd(ulong hostHwnd) => HostingHwnd = hostHwnd;
+
+    public void DebugLog(string message)
+    {
+#if DEBUG
+        this.ProcessLogMessage(new LogMessage(message));
+#endif
+    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -22,7 +22,6 @@ public partial class MainListPage : DynamicListPage,
 {
     private readonly IServiceProvider _serviceProvider;
 
-    // private readonly ObservableCollection<TopLevelCommandItemWrapper> _commands;
     private readonly TopLevelCommandManager _tlcManager;
     private IEnumerable<IListItem>? _filteredItems;
 
@@ -37,9 +36,6 @@ public partial class MainListPage : DynamicListPage,
 
         _tlcManager = _serviceProvider.GetService<TopLevelCommandManager>()!;
         _tlcManager.PropertyChanged += TlcManager_PropertyChanged;
-
-        // reference the TLC collection directly... maybe? TODO is this a good idea ot a terrible one?
-        // _commands = tlcManager.TopLevelCommands;
         _tlcManager.TopLevelCommands.CollectionChanged += Commands_CollectionChanged;
 
         WeakReferenceMessenger.Default.Register<ClearSearchMessage>(this);
@@ -128,7 +124,6 @@ public partial class MainListPage : DynamicListPage,
             // with a list of all our commands & apps.
             if (_filteredItems == null)
             {
-                // IEnumerable<IListItem> commands = _commands;
                 IEnumerable<IListItem> apps = AllAppsCommandProvider.Page.GetItems();
                 _filteredItems = commands.Concat(apps);
             }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using CommunityToolkit.Mvvm.Messaging;
@@ -23,8 +22,8 @@ public partial class MainListPage : DynamicListPage,
 {
     private readonly IServiceProvider _serviceProvider;
 
-    private readonly ObservableCollection<TopLevelCommandItemWrapper> _commands;
-
+    // private readonly ObservableCollection<TopLevelCommandItemWrapper> _commands;
+    private readonly TopLevelCommandManager _tlcManager;
     private IEnumerable<IListItem>? _filteredItems;
 
     private bool _appsLoading = true;
@@ -36,12 +35,12 @@ public partial class MainListPage : DynamicListPage,
         Icon = new(Path.Combine(AppDomain.CurrentDomain.BaseDirectory.ToString(), "Assets\\StoreLogo.scale-200.png"));
         _serviceProvider = serviceProvider;
 
-        var tlcManager = _serviceProvider.GetService<TopLevelCommandManager>()!;
-        tlcManager.PropertyChanged += TlcManager_PropertyChanged;
+        _tlcManager = _serviceProvider.GetService<TopLevelCommandManager>()!;
+        _tlcManager.PropertyChanged += TlcManager_PropertyChanged;
 
         // reference the TLC collection directly... maybe? TODO is this a good idea ot a terrible one?
-        _commands = tlcManager.TopLevelCommands;
-        _commands.CollectionChanged += Commands_CollectionChanged;
+        // _commands = tlcManager.TopLevelCommands;
+        _tlcManager.TopLevelCommands.CollectionChanged += Commands_CollectionChanged;
 
         WeakReferenceMessenger.Default.Register<ClearSearchMessage>(this);
 
@@ -60,7 +59,7 @@ public partial class MainListPage : DynamicListPage,
         }
     }
 
-    private void Commands_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => RaiseItemsChanged(_commands.Count);
+    private void Commands_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e) => RaiseItemsChanged(_tlcManager.TopLevelCommands.Count);
 
     public override IListItem[] GetItems()
     {
@@ -70,9 +69,20 @@ public partial class MainListPage : DynamicListPage,
             _startedAppLoad = true;
         }
 
-        return string.IsNullOrEmpty(SearchText)
-            ? _commands.Select(tlc => tlc).Where(tlc => !string.IsNullOrEmpty(tlc.Title)).ToArray()
-            : _filteredItems?.ToArray() ?? [];
+        if (string.IsNullOrEmpty(SearchText))
+        {
+            lock (_tlcManager.TopLevelCommands)
+            {
+                return _tlcManager.TopLevelCommands.Select(tlc => tlc).Where(tlc => !string.IsNullOrEmpty(tlc.Title)).ToArray();
+            }
+        }
+        else
+        {
+            lock (_tlcManager.TopLevelCommands)
+            {
+                return _filteredItems?.ToArray() ?? [];
+            }
+        }
     }
 
     public override void UpdateSearchText(string oldSearch, string newSearch)
@@ -89,40 +99,44 @@ public partial class MainListPage : DynamicListPage,
             }
         }
 
-        // This gets called on a background thread, because ListViewModel
-        // updates the .SearchText of all extensions on a BG thread.
-        foreach (var command in _commands)
+        var commands = _tlcManager.TopLevelCommands;
+        lock (commands)
         {
-            command.TryUpdateFallbackText(newSearch);
-        }
+            // This gets called on a background thread, because ListViewModel
+            // updates the .SearchText of all extensions on a BG thread.
+            foreach (var command in commands)
+            {
+                command.TryUpdateFallbackText(newSearch);
+            }
 
-        // Cleared out the filter text? easy. Reset _filteredItems, and bail out.
-        if (string.IsNullOrEmpty(newSearch))
-        {
-            _filteredItems = null;
-            RaiseItemsChanged(_commands.Count);
-            return;
-        }
+            // Cleared out the filter text? easy. Reset _filteredItems, and bail out.
+            if (string.IsNullOrEmpty(newSearch))
+            {
+                _filteredItems = null;
+                RaiseItemsChanged(commands.Count);
+                return;
+            }
 
-        // If the new string doesn't start with the old string, then we can't
-        // re-use previous results. Reset _filteredItems, and keep er moving.
-        if (!newSearch.StartsWith(oldSearch, StringComparison.CurrentCultureIgnoreCase))
-        {
-            _filteredItems = null;
-        }
+            // If the new string doesn't start with the old string, then we can't
+            // re-use previous results. Reset _filteredItems, and keep er moving.
+            if (!newSearch.StartsWith(oldSearch, StringComparison.CurrentCultureIgnoreCase))
+            {
+                _filteredItems = null;
+            }
 
-        // If we don't have any previous filter results to work with, start
-        // with a list of all our commands & apps.
-        if (_filteredItems == null)
-        {
-            IEnumerable<IListItem> commands = _commands;
-            IEnumerable<IListItem> apps = AllAppsCommandProvider.Page.GetItems();
-            _filteredItems = commands.Concat(apps);
-        }
+            // If we don't have any previous filter results to work with, start
+            // with a list of all our commands & apps.
+            if (_filteredItems == null)
+            {
+                // IEnumerable<IListItem> commands = _commands;
+                IEnumerable<IListItem> apps = AllAppsCommandProvider.Page.GetItems();
+                _filteredItems = commands.Concat(apps);
+            }
 
-        // Produce a list of everything that matches the current filter.
-        _filteredItems = ListHelpers.FilterList<IListItem>(_filteredItems, SearchText, ScoreTopLevelItem);
-        RaiseItemsChanged(_filteredItems.Count());
+            // Produce a list of everything that matches the current filter.
+            _filteredItems = ListHelpers.FilterList<IListItem>(_filteredItems, SearchText, ScoreTopLevelItem);
+            RaiseItemsChanged(_filteredItems.Count());
+        }
     }
 
     private bool ActuallyLoading()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionService.cs
@@ -91,6 +91,8 @@ public class ExtensionService : IExtensionService, IDisposable
         var extension = isCmdPalExtensionResult.Extension;
         if (isExtension && extension != null)
         {
+            CommandPaletteHost.Instance.DebugLog($"Installed new extension app {extension.DisplayName}");
+
             Task.Run(async () =>
             {
                 await _getInstalledExtensionsLock.WaitAsync();
@@ -117,6 +119,8 @@ public class ExtensionService : IExtensionService, IDisposable
         {
             if (extension.PackageFullName == package.Id.FullName)
             {
+                CommandPaletteHost.Instance.DebugLog($"Uninstalled extension app {extension.PackageDisplayName}");
+
                 removedExtensions.Add(extension);
             }
         }
@@ -262,8 +266,8 @@ public class ExtensionService : IExtensionService, IDisposable
                 }
                 else
                 {
-                    // TODO: throw warning or fire notification that extension declared unsupported extension interface
-                    // https://github.com/microsoft/DevHome/issues/617
+                    // log warning  that extension declared unsupported extension interface
+                    CommandPaletteHost.Instance.DebugLog($"Extension {extension.DisplayName} declared an unsupported interface: {supportedInterface.Key}");
                 }
             }
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionWrapper.cs
@@ -17,6 +17,9 @@ public class ExtensionWrapper : IExtensionWrapper
 {
     private const int HResultRpcServerNotRunning = -2147023174;
 
+    private readonly string _appUserModelId;
+    private readonly string _extensionId;
+
     private readonly Lock _lock = new();
     private readonly List<ProviderType> _providerTypes = [];
 
@@ -37,7 +40,8 @@ public class ExtensionWrapper : IExtensionWrapper
         Publisher = appExtension.Package.PublisherDisplayName;
         InstalledDate = appExtension.Package.InstalledDate;
         Version = appExtension.Package.Id.Version;
-        ExtensionUniqueId = appExtension.AppInfo.AppUserModelId + "!" + appExtension.Id;
+        _appUserModelId = appExtension.AppInfo.AppUserModelId;
+        _extensionId = appExtension.Id;
     }
 
     public string PackageDisplayName { get; }
@@ -65,7 +69,7 @@ public class ExtensionWrapper : IExtensionWrapper
     /// <item>The Extension Id. This is the unique identifier of the extension within the application.</item>
     /// </list>
     /// </summary>
-    public string ExtensionUniqueId { get; }
+    public string ExtensionUniqueId => _appUserModelId + "!" + _extensionId;
 
     public bool IsRunning()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -6,14 +6,11 @@ using System.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.WinUI;
 using Microsoft.CmdPal.Extensions;
-using Microsoft.CmdPal.Extensions.Helpers;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.MainPage;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Dispatching;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
 using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
 
@@ -111,15 +108,10 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
                 var tlc = wrapper;
                 command = wrapper.Command;
                 host = tlc.ExtensionHost != null ? tlc.ExtensionHost! : host;
-#if DEBUG
                 if (tlc.ExtensionHost?.Extension != null)
                 {
-                    host.ProcessLogMessage(new LogMessage()
-                    {
-                        Message = $"Activated top-level command from {tlc.ExtensionHost.Extension.ExtensionDisplayName}",
-                    });
+                    host.DebugLog($"Activated top-level command from {tlc.ExtensionHost.Extension.ExtensionDisplayName}");
                 }
-#endif
             }
 
             if (command is IPage page)

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/LogMessage.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/LogMessage.cs
@@ -29,4 +29,9 @@ public partial class LogMessage : BaseObservable, ILogMessage
             OnPropertyChanged(nameof(State));
         }
     }
+
+    public LogMessage(string message = "")
+    {
+        _message = message;
+    }
 }

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
@@ -32,11 +32,15 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
 
     public static IconInfo WinGetIcon { get; } = new(Path.Combine(AppDomain.CurrentDomain.BaseDirectory.ToString(), "Assets\\AppList.scale-100.png"));
 
+    public static IconInfo ExtensionsIcon { get; } = new("\uEA86"); // Puzzle
+
+    public static string ExtensionsTag => "windows-commandpalette-extension";
+
     private readonly StatusMessage _errorMessage = new() { State = MessageState.Error };
 
     public WinGetExtensionPage(string tag = "")
     {
-        Icon = WinGetIcon;
+        Icon = tag == ExtensionsTag ? ExtensionsIcon : WinGetIcon;
         Name = "Search Winget";
         _tag = tag;
         ShowDetails = true;

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/WinGetExtensionCommandsProvider.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/WinGetExtensionCommandsProvider.cs
@@ -24,11 +24,10 @@ public partial class WinGetExtensionCommandsProvider : CommandProvider
         new ListItem(new WinGetExtensionPage()),
 
          new ListItem(
-            new WinGetExtensionPage("windows-commandpalette-extension") { Title = "Install Extensions" })
+            new WinGetExtensionPage(WinGetExtensionPage.ExtensionsTag) { Title = "Install Extensions" })
          {
             Title = "Install Command Palette extensions",
             Subtitle = "Search for extensions on WinGet",
-            Icon = new("\uEA86"), // Puzzle
          },
 
         new ListItem(
@@ -41,8 +40,5 @@ public partial class WinGetExtensionCommandsProvider : CommandProvider
 
     public override ICommandItem[] TopLevelCommands() => _commands;
 
-    public override void InitializeWithHost(IExtensionHost host)
-    {
-        WinGetExtensionHost.Instance.Initialize(host);
-    }
+    public override void InitializeWithHost(IExtensionHost host) => WinGetExtensionHost.Instance.Initialize(host);
 }


### PR DESCRIPTION
Closes #370 

The DevHome code was great for "I need something that can lookup extensions and enumerate all of them".

However, the DevHome code is a very blunt hammer when it comes to extensions. The only thing it tracks is "packages changed", and if it gets one of those, it just blows away all the extensions and rebuilds them. Yikes. 

This PR changes `ExtensionService` to be a scalpel. We'll keep `_installedExtensions` fresh. When we get a package install, we'll add only that package's extension to our cache, and let the `TopLevelCommandManager` know. Similarly for updates and uninstalls. 

That way, we can exactly change the top-level list as needed, rather than bluntly forcing all the extensions to reload. 

In the middle of all this, I fixed a bug where uninstalling an extension, then reloading would just fail to load extensions. This is because the old code would clear out the **whole** list of extensions when _one_ was uninstalled. That created a race where we'd be parsing the new list of all the extensions (from the reload), get an uninstall event, clear the list, then InvalidOperation as the list of extensions was modified during enumeration. 

There's a bunch more locking in here. This might drive-by #324 but hard to be sure. 

Related to #89