### PR TITLE
get rid of dependency on Wox

### DIFF
--- a/src/modules/cmdpal/Exts/EverythingExtension/EverythingExtension.csproj
+++ b/src/modules/cmdpal/Exts/EverythingExtension/EverythingExtension.csproj
@@ -28,7 +28,6 @@
 
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsExtension.csproj
+++ b/src/modules/cmdpal/Exts/HackerNewsExtension/HackerNewsExtension.csproj
@@ -29,7 +29,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/modules/cmdpal/Exts/MastodonExtension/MastodonExtension.csproj
+++ b/src/modules/cmdpal/Exts/MastodonExtension/MastodonExtension.csproj
@@ -33,7 +33,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/modules/cmdpal/Exts/MediaControlsExtension/MediaControlsExtension.csproj
+++ b/src/modules/cmdpal/Exts/MediaControlsExtension/MediaControlsExtension.csproj
@@ -28,7 +28,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WebSearch/Microsoft.CmdPal.Ext.WebSearch.csproj
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WebSearch/Microsoft.CmdPal.Ext.WebSearch.csproj
@@ -8,10 +8,19 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\launcher\Wox.Infrastructure\Wox.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\..\launcher\Wox.Plugin\Wox.Plugin.csproj" />
+    <!-- <ProjectReference Include="..\..\..\launcher\Wox.Infrastructure\Wox.Infrastructure.csproj" /> -->
+    <!-- <ProjectReference Include="..\..\..\launcher\Wox.Plugin\Wox.Plugin.csproj" /> -->
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DependentUpon>Resources.resx</DependentUpon>

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WebSearch/Microsoft.CmdPal.Ext.WebSearch.csproj
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WebSearch/Microsoft.CmdPal.Ext.WebSearch.csproj
@@ -8,8 +8,6 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <!-- <ProjectReference Include="..\..\..\launcher\Wox.Infrastructure\Wox.Infrastructure.csproj" /> -->
-    <!-- <ProjectReference Include="..\..\..\launcher\Wox.Plugin\Wox.Plugin.csproj" /> -->
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WebSearch/Pages/WebSearchListPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WebSearch/Pages/WebSearchListPage.cs
@@ -12,7 +12,7 @@ using Microsoft.CmdPal.Ext.WebSearch.Helpers;
 using Microsoft.CmdPal.Ext.WebSearch.Properties;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
-using BrowserInfo = Wox.Plugin.Common.DefaultBrowserInfo;
+using BrowserInfo = Microsoft.CmdPal.Ext.WebSearch.Helpers.DefaultBrowserInfo;
 
 namespace Microsoft.CmdPal.Ext.WebSearch.Pages;
 

--- a/src/modules/cmdpal/Exts/PokedexExtension/PokedexExtension.csproj
+++ b/src/modules/cmdpal/Exts/PokedexExtension/PokedexExtension.csproj
@@ -28,7 +28,6 @@
 
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/Exts/ProcessMonitorExtension/ProcessMonitorExtension.csproj
+++ b/src/modules/cmdpal/Exts/ProcessMonitorExtension/ProcessMonitorExtension.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj">
     </ProjectReference>
   </ItemGroup>

--- a/src/modules/cmdpal/Exts/SSHKeychainExtension/SSHKeychainExtension.csproj
+++ b/src/modules/cmdpal/Exts/SSHKeychainExtension/SSHKeychainExtension.csproj
@@ -28,7 +28,6 @@
 
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/Exts/SamplePagesExtension/SamplePagesExtension.csproj
+++ b/src/modules/cmdpal/Exts/SamplePagesExtension/SamplePagesExtension.csproj
@@ -29,7 +29,6 @@
 
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotExtension.csproj
+++ b/src/modules/cmdpal/Exts/SpongebotExtension/SpongebotExtension.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/Exts/TemplateExtension/TemplateExtension.csproj
+++ b/src/modules/cmdpal/Exts/TemplateExtension/TemplateExtension.csproj
@@ -30,7 +30,6 @@
 
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/Exts/VirtualDesktopExtension/VirtualDesktopExtension.csproj
+++ b/src/modules/cmdpal/Exts/VirtualDesktopExtension/VirtualDesktopExtension.csproj
@@ -35,7 +35,6 @@
 
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/Exts/YouTubeExtension/YouTubeExtension.csproj
+++ b/src/modules/cmdpal/Exts/YouTubeExtension/YouTubeExtension.csproj
@@ -28,7 +28,6 @@
 
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\common\Common.UI\Common.UI.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CmdPal.Extensions.Helpers\Microsoft.CmdPal.Extensions.Helpers.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Microsoft.CmdPal.UI.ViewModels.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Microsoft.CmdPal.UI.ViewModels.csproj
@@ -30,7 +30,7 @@
 
     <ProjectReference Include="..\Exts\Microsoft.CmdPal.Ext.Apps\Microsoft.CmdPal.Ext.Apps.csproj" />
 
-    <ProjectReference Include="..\..\..\common\Common.UI\Common.UI.csproj" />
+    <ProjectReference Include="..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
 
   </ItemGroup>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
@@ -117,7 +117,6 @@
       <Private>True</Private>
       <CopyLocalSatelliteAssemblies>True</CopyLocalSatelliteAssemblies>
     </ProjectReference>
-    <!-- <ProjectReference Include="..\..\..\common\Common.UI\Common.UI.csproj" /> -->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/OpenUrlCommand.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/OpenUrlCommand.cs
@@ -2,9 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using Microsoft.CmdPal.Extensions.Helpers;
-
 namespace Microsoft.CmdPal.Extensions.Helpers;
 
 public sealed partial class OpenUrlCommand : InvokableCommand
@@ -22,7 +19,7 @@ public sealed partial class OpenUrlCommand : InvokableCommand
 
     public override CommandResult Invoke()
     {
-        Process.Start(new ProcessStartInfo(_target) { UseShellExecute = true });
+        ShellHelpers.OpenInShell(_target);
         return Result;
     }
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ShellHelpers.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CmdPal.Extensions.Helpers/ShellHelpers.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace Microsoft.CmdPal.Extensions.Helpers;
+
+public static class ShellHelpers
+{
+    public static bool OpenCommandInShell(string? path, string? pattern, string? arguments, string? workingDir = null, ShellRunAsType runAs = ShellRunAsType.None, bool runWithHiddenWindow = false)
+    {
+        if (string.IsNullOrEmpty(pattern))
+        {
+            // Log.Warn($"Trying to run OpenCommandInShell with an empty pattern. The default browser definition might have issues. Path: '${path ?? string.Empty}' ; Arguments: '${arguments ?? string.Empty}' ; Working Directory: '${workingDir ?? string.Empty}'", typeof(ShellHelpers));
+        }
+        else if (pattern.Contains("%1", StringComparison.Ordinal))
+        {
+            arguments = pattern.Replace("%1", arguments);
+        }
+
+        return OpenInShell(path, arguments, workingDir, runAs, runWithHiddenWindow);
+    }
+
+    public static bool OpenInShell(string? path, string? arguments = null, string? workingDir = null, ShellRunAsType runAs = ShellRunAsType.None, bool runWithHiddenWindow = false)
+    {
+        using var process = new Process();
+        process.StartInfo.FileName = path;
+        process.StartInfo.WorkingDirectory = string.IsNullOrWhiteSpace(workingDir) ? string.Empty : workingDir;
+        process.StartInfo.Arguments = string.IsNullOrWhiteSpace(arguments) ? string.Empty : arguments;
+        process.StartInfo.WindowStyle = runWithHiddenWindow ? ProcessWindowStyle.Hidden : ProcessWindowStyle.Normal;
+        process.StartInfo.UseShellExecute = true;
+
+        if (runAs == ShellRunAsType.Administrator)
+        {
+            process.StartInfo.Verb = "RunAs";
+        }
+        else if (runAs == ShellRunAsType.OtherUser)
+        {
+            process.StartInfo.Verb = "RunAsUser";
+        }
+
+        try
+        {
+            process.Start();
+            return true;
+        }
+        catch (Win32Exception)
+        {
+            // Log.Exception($"Unable to open {path}: {ex.Message}", ex, MethodBase.GetCurrentMethod().DeclaringType);
+            return false;
+        }
+    }
+
+    public enum ShellRunAsType
+    {
+        None,
+        Administrator,
+        OtherUser,
+    }
+}

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/Commands/SearchWebCommand.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/Commands/SearchWebCommand.cs
@@ -6,8 +6,9 @@ using System;
 using Microsoft.CmdPal.Ext.WebSearch.Helpers;
 using Microsoft.CmdPal.Ext.WebSearch.Properties;
 using Microsoft.CmdPal.Extensions.Helpers;
-using Wox.Infrastructure;
-using BrowserInfo = Wox.Plugin.Common.DefaultBrowserInfo;
+
+// using Wox.Infrastructure;
+using BrowserInfo = Microsoft.CmdPal.Ext.WebSearch.Helpers.DefaultBrowserInfo;
 
 namespace Microsoft.CmdPal.Ext.WebSearch.Commands;
 
@@ -28,7 +29,7 @@ internal sealed partial class SearchWebCommand : InvokableCommand
 
     public override CommandResult Invoke()
     {
-        if (!Helper.OpenCommandInShell(BrowserInfo.Path, BrowserInfo.ArgumentsPattern, $"? {Arguments}"))
+        if (!ShellHelpers.OpenCommandInShell(BrowserInfo.Path, BrowserInfo.ArgumentsPattern, $"? {Arguments}"))
         {
             // TODO GH# 138 --> actually display feedback from the extension somewhere.
             return CommandResult.KeepOpen();

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/Commands/SearchWebCommand.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/Commands/SearchWebCommand.cs
@@ -7,7 +7,6 @@ using Microsoft.CmdPal.Ext.WebSearch.Helpers;
 using Microsoft.CmdPal.Ext.WebSearch.Properties;
 using Microsoft.CmdPal.Extensions.Helpers;
 
-// using Wox.Infrastructure;
 using BrowserInfo = Microsoft.CmdPal.Ext.WebSearch.Helpers.DefaultBrowserInfo;
 
 namespace Microsoft.CmdPal.Ext.WebSearch.Commands;

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.Text;
 using Microsoft.CmdPal.Ext.WebSearch.Helpers;
 using Microsoft.CmdPal.Extensions.Helpers;
-using BrowserInfo = Wox.Plugin.Common.DefaultBrowserInfo;
+using BrowserInfo = Microsoft.CmdPal.Ext.WebSearch.Helpers.DefaultBrowserInfo;
 
 namespace Microsoft.CmdPal.Ext.WebSearch.Commands;
 

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/Helpers/DefaultBrowserInfo.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/Helpers/DefaultBrowserInfo.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.CmdPal.Ext.WebSearch.Helpers;
+
+/// <summary>
+/// Contains information (e.g. path to executable, name...) about the default browser.
+/// </summary>
+public static class DefaultBrowserInfo
+{
+    private static readonly Lock _updateLock = new();
+
+    /// <summary>Gets the path to the MS Edge browser executable.</summary>
+    public static string MSEdgePath => System.IO.Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+        @"Microsoft\Edge\Application\msedge.exe");
+
+    /// <summary>Gets the command line pattern of the MS Edge.</summary>
+    public const string MSEdgeArgumentsPattern = "--single-argument %1";
+
+    public const string MSEdgeName = "Microsoft Edge";
+
+    /// <summary>Gets the path to default browser's executable.</summary>
+    public static string? Path { get; private set; }
+
+    /// <summary>Gets <see cref="Path"/> since the icon is embedded in the executable.</summary>
+    public static string? IconPath => Path;
+
+    /// <summary>Gets the user-friendly name of the default browser.</summary>
+    public static string? Name { get; private set; }
+
+    /// <summary>Gets the command line pattern of the default browser.</summary>
+    public static string? ArgumentsPattern { get; private set; }
+
+    public static bool IsDefaultBrowserSet => !string.IsNullOrEmpty(Path);
+
+    public const long UpdateTimeout = 300;
+
+    private static long _lastUpdateTickCount = -UpdateTimeout;
+
+    private static bool _updatedOnce;
+    private static bool _errorLogged;
+
+    /// <summary>
+    /// Updates only if at least more than 300ms has passed since the last update, to avoid multiple calls to <see cref="Update"/>.
+    /// (because of multiple plugins calling update at the same time.)
+    /// </summary>
+    public static void UpdateIfTimePassed()
+    {
+        var curTickCount = Environment.TickCount64;
+        if (curTickCount - _lastUpdateTickCount >= UpdateTimeout)
+        {
+            _lastUpdateTickCount = curTickCount;
+            Update();
+        }
+    }
+
+    /// <summary>
+    /// Consider using <see cref="UpdateIfTimePassed"/> to avoid updating multiple times.
+    /// (because of multiple plugins calling update at the same time.)
+    /// </summary>
+    public static void Update()
+    {
+        lock (_updateLock)
+        {
+            if (!_updatedOnce)
+            {
+                // Log.Info("I've tried updating the chosen Web Browser info at least once.", typeof(DefaultBrowserInfo));
+                _updatedOnce = true;
+            }
+
+            try
+            {
+                var progId = GetRegistryValue(
+                    @"HKEY_CURRENT_USER\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice",
+                    "ProgId");
+                var appName = GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}\Application", "ApplicationName")
+                    ?? GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}", "FriendlyTypeName");
+
+                if (appName != null)
+                {
+                    // Handle indirect strings:
+                    if (appName.StartsWith('@'))
+                    {
+                        appName = GetIndirectString(appName);
+                    }
+
+                    appName = appName
+                        .Replace("URL", null, StringComparison.OrdinalIgnoreCase)
+                        .Replace("HTML", null, StringComparison.OrdinalIgnoreCase)
+                        .Replace("Document", null, StringComparison.OrdinalIgnoreCase)
+                        .Replace("Web", null, StringComparison.OrdinalIgnoreCase)
+                        .TrimEnd();
+                }
+
+                Name = appName;
+
+                var commandPattern = GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}\shell\open\command", null);
+
+                if (string.IsNullOrEmpty(commandPattern))
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(commandPattern),
+                        "Default browser program command is not specified.");
+                }
+
+                if (commandPattern.StartsWith('@'))
+                {
+                    commandPattern = GetIndirectString(commandPattern);
+                }
+
+                // HACK: for firefox installed through Microsoft store
+                // When installed through Microsoft Firefox the commandPattern does not have
+                // quotes for the path. As the Program Files does have a space
+                // the extracted path would be invalid, here we add the quotes to fix it
+                const string FirefoxExecutableName = "firefox.exe";
+                if (commandPattern.Contains(FirefoxExecutableName) && commandPattern.Contains(@"\WindowsApps\") && (!commandPattern.StartsWith('\"')))
+                {
+                    var pathEndIndex = commandPattern.IndexOf(FirefoxExecutableName, StringComparison.Ordinal) + FirefoxExecutableName.Length;
+                    commandPattern = commandPattern.Insert(pathEndIndex, "\"");
+                    commandPattern = commandPattern.Insert(0, "\"");
+                }
+
+                if (commandPattern.StartsWith('\"'))
+                {
+                    var endQuoteIndex = commandPattern.IndexOf('\"', 1);
+                    if (endQuoteIndex != -1)
+                    {
+                        Path = commandPattern.Substring(1, endQuoteIndex - 1);
+                        ArgumentsPattern = commandPattern.Substring(endQuoteIndex + 1).Trim();
+                    }
+                }
+                else
+                {
+                    var spaceIndex = commandPattern.IndexOf(' ');
+                    if (spaceIndex != -1)
+                    {
+                        Path = commandPattern.Substring(0, spaceIndex);
+                        ArgumentsPattern = commandPattern.Substring(spaceIndex + 1).Trim();
+                    }
+                }
+
+                // Packaged applications could be an URI. Example: shell:AppsFolder\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe!App
+                if (!System.IO.Path.Exists(Path) && !Uri.TryCreate(Path, UriKind.Absolute, out _))
+                {
+                    throw new ArgumentException(
+                        $"Command validation failed: {commandPattern}",
+                        nameof(commandPattern));
+                }
+
+                if (string.IsNullOrEmpty(Path))
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(Path),
+                        "Default browser program path could not be determined.");
+                }
+            }
+            catch (Exception)
+            {
+                // Fallback to MS Edge
+                Path = MSEdgePath;
+                Name = MSEdgeName;
+                ArgumentsPattern = MSEdgeArgumentsPattern;
+
+                if (!_errorLogged)
+                {
+                    // Log.Exception("Exception when retrieving browser path/name. Path and Name are set to use Microsoft Edge.", e, typeof(DefaultBrowserInfo));
+                    _errorLogged = true;
+                }
+            }
+
+            string? GetRegistryValue(string registryLocation, string? valueName)
+            {
+                return Microsoft.Win32.Registry.GetValue(registryLocation, valueName, null) as string;
+            }
+
+            string GetIndirectString(string str)
+            {
+                var stringBuilder = new StringBuilder(128);
+                unsafe
+                {
+                    var buffer = stackalloc char[128];
+                    var capacity = 128;
+                    void* reserved = null;
+
+                    // S_OK == 0
+                    if (global::Windows.Win32.PInvoke.SHLoadIndirectString(
+                            str,
+                            buffer,
+                            (uint)capacity,
+                            ref reserved)
+                        == 0)
+                    {
+                        return new string(buffer);
+                    }
+                }
+
+                throw new ArgumentNullException(nameof(str), "Could not load indirect string.");
+            }
+        }
+    }
+}

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/NativeMethods.txt
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WebSearch/NativeMethods.txt
@@ -1,0 +1,1 @@
+SHLoadIndirectString


### PR DESCRIPTION
Closes #363

The WebSearch plugin pulled in all of Wox.Infrastructure, which resulted in us pulling in _all of WPF_ as a dependency, which we obviously don't need.