### PR TITLE
Attempt to correlate apps to winget packages

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsCommandProvider.cs
@@ -28,7 +28,30 @@ public partial class AllAppsCommandProvider : CommandProvider
     public ICommandItem? LookupApp(string displayName)
     {
         var items = Page.GetItems();
-        var match = items.Where(i => i.Title == displayName).FirstOrDefault();
-        return match;
+
+        // We're going to do this search in two directions:
+        // First, is this name a substring of any app...
+        var nameMatches = items.Where(i => i.Title.Contains(displayName));
+
+        // ... Then, does any app have this name as a substring ...
+        // Only get one of these - "Terminal Preview" contains both "Terminal" and "Terminal Preview", so just take the best one
+        var appMatches = items.Where(i => displayName.Contains(i.Title)).OrderByDescending(i => i.Title.Length).Take(1);
+
+        // ... Now, combine those two
+        var both = nameMatches.Concat(appMatches);
+
+        if (both.Count() == 1)
+        {
+            return both.First();
+        }
+        else if (nameMatches.Count() == 1 && appMatches.Count() == 1)
+        {
+            if (nameMatches.First() == appMatches.First())
+            {
+                return nameMatches.First();
+            }
+        }
+
+        return null;
     }
 }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsCommandProvider.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.CmdPal.Extensions;
 using Microsoft.CmdPal.Extensions.Helpers;
 
@@ -23,4 +24,11 @@ public partial class AllAppsCommandProvider : CommandProvider
     }
 
     public override ICommandItem[] TopLevelCommands() => [_listItem];
+
+    public ICommandItem? LookupApp(string displayName)
+    {
+        var items = Page.GetItems();
+        var match = items.Where(i => i.Title == displayName).FirstOrDefault();
+        return match;
+    }
 }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
@@ -37,6 +37,10 @@ public sealed partial class AllAppsPage : ListPage
         return allAppsSection;
     }
 
+    // public ICommandItem? LookupApp(string displayName)
+    // {
+
+    // }
     internal static List<AppItem> GetPrograms()
     {
         // NOTE TO SELF:

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
@@ -37,10 +37,6 @@ public sealed partial class AllAppsPage : ListPage
         return allAppsSection;
     }
 
-    // public ICommandItem? LookupApp(string displayName)
-    // {
-
-    // }
     internal static List<AppItem> GetPrograms()
     {
         // NOTE TO SELF:

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ActionBarViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ActionBarViewModel.cs
@@ -27,7 +27,7 @@ public partial class ActionBarViewModel : ObservableObject,
     [NotifyPropertyChangedFor(nameof(HasPrimaryCommand))]
     public partial CommandItemViewModel? PrimaryAction { get; set; }
 
-    public bool HasPrimaryCommand => PrimaryAction != null;
+    public bool HasPrimaryCommand => PrimaryAction != null && PrimaryAction.ShouldBeVisible;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasSecondaryCommand))]

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -33,9 +33,11 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
 
     public bool HasMoreCommands => MoreCommands.Count > 0;
 
-    public string SecondaryCommandName => HasMoreCommands ? MoreCommands[0].Name : string.Empty;
+    public string SecondaryCommandName => SecondaryCommand?.Name ?? string.Empty;
 
     public CommandItemViewModel? SecondaryCommand => HasMoreCommands ? MoreCommands[0] : null;
+
+    public bool ShouldBeVisible => !string.IsNullOrEmpty(Name);
 
     public List<CommandContextItemViewModel> AllCommands
     {
@@ -179,7 +181,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel
                 break;
             case nameof(Icon):
                 var listIcon = model.Icon;
-                var iconInfo = listIcon != null ? listIcon : Command.Unsafe!.Icon;
+                var iconInfo = listIcon ?? Command.Unsafe!.Icon;
                 Icon = new(iconInfo);
                 Icon.InitializeProperties();
                 break;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -77,7 +77,11 @@ public partial class App : Application
         services.AddSingleton(TaskScheduler.FromCurrentSynchronizationContext());
 
         // Built-in Commands. Order matters - this is the order they'll be presented by default.
-        services.AddSingleton<ICommandProvider, AllAppsCommandProvider>();
+        var allApps = new AllAppsCommandProvider();
+        var winget = new WinGetExtensionCommandsProvider();
+        var callback = allApps.LookupApp;
+        winget.SetAllLookup(callback);
+        services.AddSingleton<ICommandProvider>(allApps);
         services.AddSingleton<ICommandProvider, ShellCommandsProvider>();
         services.AddSingleton<ICommandProvider, CalculatorCommandProvider>();
         services.AddSingleton<ICommandProvider, IndexerCommandsProvider>();
@@ -85,7 +89,7 @@ public partial class App : Application
         services.AddSingleton<ICommandProvider, BookmarksCommandProvider>();
         services.AddSingleton<ICommandProvider, WindowWalkerCommandsProvider>();
         services.AddSingleton<ICommandProvider, WebSearchCommandsProvider>();
-        services.AddSingleton<ICommandProvider, WinGetExtensionCommandsProvider>();
+        services.AddSingleton<ICommandProvider>(winget);
         services.AddSingleton<ICommandProvider, WindowsTerminalCommandsProvider>();
         services.AddSingleton<ICommandProvider, WindowsSettingsCommandsProvider>();
         services.AddSingleton<ICommandProvider, RegistryCommandsProvider>();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Program.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Program.cs
@@ -47,7 +47,7 @@ internal sealed class Program
         else
         {
             isRedirect = true;
-            _ = keyInstance.RedirectActivationToAsync(args);
+            keyInstance.RedirectActivationToAsync(args).AsTask().ConfigureAwait(false);
         }
 
         return isRedirect;
@@ -55,9 +55,6 @@ internal sealed class Program
 
     private static void OnActivated(object? sender, AppActivationArguments args)
     {
-        var kind = args.Kind;
-        _ = kind;
-
         // If we already have a form, display the message now.
         // Otherwise, add it to the collection for displaying later.
         if (App.Current is App thisApp)

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageCommand.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageCommand.cs
@@ -27,6 +27,8 @@ public partial class InstallPackageCommand : InvokableCommand
 
     public static IconInfo DownloadIcon { get; } = new("\uE896"); // Download
 
+    public static IconInfo DeleteIcon { get; } = new("\uE74D"); // Delete
+
     public event EventHandler<InstallPackageCommand>? InstallStateChanged;
 
     public InstallPackageCommand(CatalogPackage package, bool isInstalled)

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageListItem.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageListItem.cs
@@ -126,10 +126,25 @@ public partial class InstallPackageListItem : ListItem
     {
         var status = await _package.CheckInstalledStatusAsync();
         var isInstalled = _package.InstalledVersion != null;
+
+        if (WinGetStatics.AppSearchCallback != null)
+        {
+            var callback = WinGetStatics.AppSearchCallback;
+            var installedApp = callback(_package.DefaultInstallVersion.DisplayName);
+            if (installedApp != null)
+            {
+                this.Command = installedApp.Command;
+                this.MoreCommands = installedApp.MoreCommands;
+                this.Icon = InstallPackageCommand.CompletedIcon;
+                return;
+            }
+        }
+
+        // didn't find the app
         _installCommand = new InstallPackageCommand(_package, isInstalled);
         this.Command = _installCommand;
-        Icon = _installCommand.Icon;
 
+        Icon = _installCommand.Icon;
         _installCommand.InstallStateChanged += InstallStateChangedHandler;
     }
 

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageListItem.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageListItem.cs
@@ -130,7 +130,12 @@ public partial class InstallPackageListItem : ListItem
             this.Icon = InstallPackageCommand.CompletedIcon;
             this.Command = new NoOpCommand();
             List<IContextItem> contextMenu = [];
-            var uninstallContextItem = new CommandContextItem(installCommand) { IsCritical = true };
+            var uninstallContextItem = new CommandContextItem(installCommand)
+            {
+                IsCritical = true,
+                Icon = InstallPackageCommand.DeleteIcon,
+            };
+
             if (WinGetStatics.AppSearchCallback != null)
             {
                 var callback = WinGetStatics.AppSearchCallback;

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/WinGetExtensionCommandsProvider.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/WinGetExtensionCommandsProvider.cs
@@ -41,4 +41,6 @@ public partial class WinGetExtensionCommandsProvider : CommandProvider
     public override ICommandItem[] TopLevelCommands() => _commands;
 
     public override void InitializeWithHost(IExtensionHost host) => WinGetExtensionHost.Instance.Initialize(host);
+
+    public void SetAllLookup(Func<string, ICommandItem?> callback) => WinGetStatics.AppSearchCallback = callback;
 }

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/WinGetStatics.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/WinGetStatics.cs
@@ -31,6 +31,8 @@ internal static class WinGetStatics
 
     private static readonly StatusMessage _errorMessage = new() { State = MessageState.Error };
 
+    public static Func<string, ICommandItem?>? AppSearchCallback { get; set; }
+
     static WinGetStatics()
     {
         WinGetFactory = new WindowsPackageManagerStandardFactory();


### PR DESCRIPTION
This is a first best effort at #367. 

If an app is installed, we'll try to lookup if there's one and only app with that name in our big list of apps. If there is, then we'll set the command on the winget list to the "run" command. 

The uninstall command moves into the context menu, always. Even if we don't find it. This will make it harder to accidentally uninstall things. 

This also has another drive-by fix for #357. Problem wasn't just being on the UI thread, it's that we were trying to get the `.Kind` out of the activation args, after the spawning process had already died. 