### PR TITLE
Change the default hotkey to Win+alt+space

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -22,7 +22,7 @@ public partial class SettingsModel : ObservableObject
 
     ///////////////////////////////////////////////////////////////////////////
     // SETTINGS HERE
-    public HotkeySettings? Hotkey { get; set; } = new HotkeySettings(true, true, false, false, 0xBE);
+    public HotkeySettings? Hotkey { get; set; } = new HotkeySettings(true, false, true, false, 0x20); // win+alt+space
 
     public bool ShowAppDetails { get; set; }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/IconCacheService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/IconCacheService.cs
@@ -39,7 +39,7 @@ public sealed class IconCacheService(DispatcherQueue dispatcherQueue)
                 }
                 catch
                 {
-                    Debug.WriteLine("Failed to load icon from streasm");
+                    Debug.WriteLine("Failed to load icon from stream");
                 }
             }
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/IconCacheService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/IconCacheService.cs
@@ -39,7 +39,7 @@ public sealed class IconCacheService(DispatcherQueue dispatcherQueue)
                 }
                 catch
                 {
-                    Debug.WriteLine("Failed to load icon from stream");
+                    Debug.WriteLine("Failed to load icon from streasm");
                 }
             }
         }


### PR DESCRIPTION
Title

This is just a much simpler keybind. It harkens the mind to `alt+space`, without actually stealing that keybinding. 

I recommend `ctrl+alt+space` for the dev version (though, I'm not setting that for you)