### PR TITLE
Developer XAML version of TextToSuggest

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -82,7 +82,11 @@ public partial class ListViewModel : PageViewModel
         else
         {
             // But for all normal pages, we should run our fuzzy match on them.
-            ApplyFilter();
+            lock (FilteredItems)
+            {
+                ApplyFilterUnderLock();
+            }
+
             ItemsUpdated?.Invoke(this, EventArgs.Empty);
         }
     }
@@ -113,9 +117,12 @@ public partial class ListViewModel : PageViewModel
                 }
             }
 
-            // Now that we have new ViewModels for everything from the
-            // extension, smartly update our list of VMs
-            ListHelpers.InPlaceUpdateList(Items, newViewModels);
+            lock (Items)
+            {
+                // Now that we have new ViewModels for everything from the
+                // extension, smartly update our list of VMs
+                ListHelpers.InPlaceUpdateList(Items, newViewModels);
+            }
 
             // TODO: Iterate over everything in Items, and prune items from the
             // cache if we don't need them anymore
@@ -131,18 +138,21 @@ public partial class ListViewModel : PageViewModel
         Task.Factory.StartNew(
             () =>
             {
-                // Now that our Items contains everything we want, it's time for us to
-                // re-evaluate our Filter on those items.
-                if (!_isDynamic)
+                lock (FilteredItems)
                 {
-                    // A static list? Great! Just run the filter.
-                    ApplyFilter();
-                }
-                else
-                {
-                    // A dynamic list? Even better! Just stick everything into
-                    // FilteredItems. The extension already did any filtering it cared about.
-                    ListHelpers.InPlaceUpdateList(FilteredItems, Items);
+                    // Now that our Items contains everything we want, it's time for us to
+                    // re-evaluate our Filter on those items.
+                    if (!_isDynamic)
+                    {
+                        // A static list? Great! Just run the filter.
+                        ApplyFilterUnderLock();
+                    }
+                    else
+                    {
+                        // A dynamic list? Even better! Just stick everything into
+                        // FilteredItems. The extension already did any filtering it cared about.
+                        ListHelpers.InPlaceUpdateList(FilteredItems, Items);
+                    }
                 }
 
                 ItemsUpdated?.Invoke(this, EventArgs.Empty);
@@ -156,7 +166,7 @@ public partial class ListViewModel : PageViewModel
     /// Apply our current filter text to the list of items, and update
     /// FilteredItems to match the results.
     /// </summary>
-    private void ApplyFilter() => ListHelpers.InPlaceUpdateList(FilteredItems, FilterList(Items, Filter));
+    private void ApplyFilterUnderLock() => ListHelpers.InPlaceUpdateList(FilteredItems, FilterList(Items, Filter));
 
     /// <summary>
     /// Helper to generate a weighting for a given list item, based on title,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -226,6 +226,8 @@ public partial class ListViewModel : PageViewModel
                {
                    WeakReferenceMessenger.Default.Send<HideDetailsMessage>();
                }
+
+               TextToSuggest = item.TextToSuggest;
            },
            CancellationToken.None,
            TaskCreationOptions.None,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
@@ -36,6 +36,9 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
     public virtual partial string PlaceholderText { get; private set; } = "Type here to search...";
 
     [ObservableProperty]
+    public virtual partial string TextToSuggest { get; protected set; } = string.Empty;
+
+    [ObservableProperty]
     public partial CommandPaletteHost ExtensionHost { get; private set; }
 
     public bool HasStatusMessage => MostRecentStatusMessage != null;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml
@@ -3,9 +3,9 @@
     x:Class="Microsoft.CmdPal.UI.Controls.SearchBar"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:cpcontrols="using:Microsoft.CmdPal.UI.Controls"
     xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+    xmlns:cpcontrols="using:Microsoft.CmdPal.UI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
@@ -22,8 +22,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <StackPanel Orientation="Horizontal"
-            MinHeight="32">
+    <StackPanel MinHeight="32" Orientation="Horizontal">
         <!--  Search box  -->
         <TextBox
             x:Name="FilterBox"
@@ -38,31 +37,28 @@
             TextChanged="FilterBox_TextChanged" />
 
         <Border
-            Padding="4"
             Margin="0,2,0,0"
+            Padding="4"
             VerticalAlignment="Center"
             Background="Transparent"
             BorderBrush="{ThemeResource TextFillColorSecondaryBrush}"
             BorderThickness="1"
-            Visibility="{x:Bind CurrentPageViewModel.TextToSuggest, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}"
-            
-            CornerRadius="4">
+            CornerRadius="4"
+            Visibility="{x:Bind CurrentPageViewModel.TextToSuggest, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}">
             <FontIcon
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
                 FontSize="8"
                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                Glyph="&#xEBE7;" /> <!--Right Arrow Key-->
+                Glyph="&#xEBE7;" /> 
+            <!--  Right Arrow Key  -->
         </Border>
         <TextBlock
             MinHeight="32"
             Padding="{ThemeResource TextControlThemePadding}"
             VerticalAlignment="Stretch"
-            
+            Foreground="{ThemeResource TextControlPlaceholderForeground}"
             Text="{x:Bind CurrentPageViewModel.TextToSuggest, Mode=OneWay}"
-            Visibility="{x:Bind CurrentPageViewModel.TextToSuggest, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}"
-            Foreground="{ThemeResource TextControlPlaceholderForeground}">
-            
-        </TextBlock>
+            Visibility="{x:Bind CurrentPageViewModel.TextToSuggest, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}" />
     </StackPanel>
 </UserControl>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml
@@ -4,21 +4,65 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:Microsoft.CmdPal.UI.Controls"
+    xmlns:cpcontrols="using:Microsoft.CmdPal.UI.Controls"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <!--  Search box  -->
-    <TextBox
-        x:Name="FilterBox"
-        MinHeight="32"
-        VerticalAlignment="Stretch"
-        VerticalContentAlignment="Stretch"
-        KeyDown="FilterBox_KeyDown"
-        PlaceholderText="{x:Bind CurrentPageViewModel.PlaceholderText, Mode=OneWay}"
-        PreviewKeyDown="FilterBox_PreviewKeyDown"
-        PreviewKeyUp="FilterBox_PreviewKeyUp"
-        Style="{StaticResource SearchTextBoxStyle}"
-        TextChanged="FilterBox_TextChanged" />
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <converters:StringVisibilityConverter
+                x:Key="StringNotEmptyToVisibilityConverter"
+                EmptyValue="Collapsed"
+                NotEmptyValue="Visible" />
+            <converters:StringVisibilityConverter
+                x:Key="InvertedStringVisibilityConverter"
+                EmptyValue="Visible"
+                NotEmptyValue="Collapsed" />
+        </ResourceDictionary>
+    </UserControl.Resources>
 
+    <StackPanel Orientation="Horizontal"
+            MinHeight="32">
+        <!--  Search box  -->
+        <TextBox
+            x:Name="FilterBox"
+            MinHeight="32"
+            VerticalAlignment="Stretch"
+            VerticalContentAlignment="Stretch"
+            KeyDown="FilterBox_KeyDown"
+            PlaceholderText="{x:Bind CurrentPageViewModel.PlaceholderText, Mode=OneWay}"
+            PreviewKeyDown="FilterBox_PreviewKeyDown"
+            PreviewKeyUp="FilterBox_PreviewKeyUp"
+            Style="{StaticResource SearchTextBoxStyle}"
+            TextChanged="FilterBox_TextChanged" />
+
+        <Border
+            Padding="4"
+            Margin="0,2,0,0"
+            VerticalAlignment="Center"
+            Background="Transparent"
+            BorderBrush="{ThemeResource TextFillColorSecondaryBrush}"
+            BorderThickness="1"
+            Visibility="{x:Bind CurrentPageViewModel.TextToSuggest, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}"
+            
+            CornerRadius="4">
+            <FontIcon
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                FontSize="8"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Glyph="&#xEBE7;" /> <!--Right Arrow Key-->
+        </Border>
+        <TextBlock
+            MinHeight="32"
+            Padding="{ThemeResource TextControlThemePadding}"
+            VerticalAlignment="Stretch"
+            
+            Text="{x:Bind CurrentPageViewModel.TextToSuggest, Mode=OneWay}"
+            Visibility="{x:Bind CurrentPageViewModel.TextToSuggest, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}"
+            Foreground="{ThemeResource TextControlPlaceholderForeground}">
+            
+        </TextBlock>
+    </StackPanel>
 </UserControl>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -134,6 +134,15 @@ public sealed partial class SearchBar : UserControl,
             WeakReferenceMessenger.Default.Send<OpenContextMenuMessage>();
             e.Handled = true;
         }
+        else if (e.Key == VirtualKey.Right)
+        {
+            if (CurrentPageViewModel != null && !string.IsNullOrEmpty(CurrentPageViewModel.TextToSuggest))
+            {
+                FilterBox.Text = CurrentPageViewModel.TextToSuggest;
+                FilterBox.Select(FilterBox.Text.Length, 0);
+                e.Handled = true;
+            }
+        }
         else if (e.Key == VirtualKey.Escape)
         {
             if (string.IsNullOrEmpty(FilterBox.Text))

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ListHelpers.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ListHelpers.cs
@@ -89,7 +89,7 @@ public partial class ListHelpers
             for (var j = i; j < original.Count; j++)
             {
                 var og_2 = original[j];
-                var areEqual_2 = og_2.Equals(newItem);
+                var areEqual_2 = og_2?.Equals(newItem) ?? false;
                 if (areEqual_2)
                 {
                     for (var k = i; k < j; k++)
@@ -103,7 +103,7 @@ public partial class ListHelpers
             }
 
             var og = original[i];
-            var areEqual = og.Equals(newItem);
+            var areEqual = og?.Equals(newItem) ?? false;
 
             // Is this new item already in the list?
             if (areEqual)


### PR DESCRIPTION
This is just a very rough prototype of "TextToSuggest", to make it do _something_. I'll link this to #358, but it's not clean enough to close it. 

I just slapped a TextBlock with the suggested text to the right of the input, just so users can see that there is a suggestion and that you can press `right` to accept it. 

The best extension to test this with is the Registry one, but that crashes heavily in `ListHelpers.InPlaceUpdateList`. I think it's for two reasons:
* a null item in the list? (we should ignore that!)
* and we're modifying the list as we're updating it (definitely shouldn't do that)

I'm guessing the second is actually the cause of #324, though I've had a hard time reproing that as of late.