### PR TITLE
Fix the HostingHwnd for built-in

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteHost.cs
@@ -19,7 +19,9 @@ public sealed partial class CommandPaletteHost : IExtensionHost
 
     private static readonly GlobalLogPageContext _globalLogPageContext = new();
 
-    public ulong HostingHwnd { get; private set; }
+    private static ulong _hostingHwnd;
+
+    public ulong HostingHwnd => _hostingHwnd;
 
     public string LanguageOverride => string.Empty;
 
@@ -173,7 +175,7 @@ public sealed partial class CommandPaletteHost : IExtensionHost
             _globalLogPageContext.Scheduler);
     }
 
-    public void SetHostHwnd(ulong hostHwnd) => HostingHwnd = hostHwnd;
+    public static void SetHostHwnd(ulong hostHwnd) => _hostingHwnd = hostHwnd;
 
     public void DebugLog(string message)
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -5,7 +5,6 @@
 using System.Runtime.InteropServices;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.CmdPal.Common.Services;
-using Microsoft.CmdPal.UI.Pages;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.CmdPal.UI.ViewModels.Settings;
@@ -59,7 +58,7 @@ public sealed partial class MainWindow : Window,
         InitializeComponent();
 
         _hwnd = new HWND(WinRT.Interop.WindowNative.GetWindowHandle(this).ToInt32());
-        CommandPaletteHost.Instance.SetHostHwnd((ulong)_hwnd.Value);
+        CommandPaletteHost.SetHostHwnd((ulong)_hwnd.Value);
 
         // TaskbarCreated is the message that's broadcast when explorer.exe
         // restarts. We need to know when that happens to be able to bring our


### PR DESCRIPTION
This static `CommandPaletteHost` instance is definitely problematic, and we should fix that. 

But for now, this fixes the issue where all extensions (including builtins) couldn't access the HWND.

We need this for #151, and it might help resolve what we were seeing in #152 