### PR TITLE
Add rudimentary support for Toast messages

### DIFF
--- a/.github/actions/spell-check/allow/names.txt
+++ b/.github/actions/spell-check/allow/names.txt
@@ -197,6 +197,7 @@ cortana
 dlnilsson
 fancymouse
 firefox
+fudan
 gpt
 Inkscape
 Markdig
@@ -212,6 +213,7 @@ regedit
 roslyn
 Spotify
 Vanara
+wangyi
 WEX
 windowwalker
 winui
@@ -219,6 +221,7 @@ winuiex
 wix
 wordpad
 WWL
+wyhash
 xamlstyler
 Xavalon
 Xbox

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1294,6 +1294,44 @@ EXHIBIT A -Mozilla Public License.
      Original Code Source Code for Your Modifications.]
 ```
 
+## Utility: Command Palette
+
+### wyhash
+
+We use the WyHash NuGet package for calculating stable hashes for strings.
+
+**Source**: [https://github.com/wangyi-fudan/wyhash](https://github.com/wangyi-fudan/wyhash)
+
+### License
+
+```
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>
+```
+
+
 ## NuGet Packages used by PowerToys
 
 
@@ -1383,3 +1421,4 @@ EXHIBIT A -Mozilla Public License.
 - UTF.Unknown 2.5.1
 - WinUIEx 2.2.0
 - WPF-UI 3.0.5
+- WyHash 1.0.5

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
@@ -151,7 +151,7 @@ internal sealed partial class FallbackCalculatorItem : FallbackCommandItem
         if (CalculatorListPage.ParseQuery(query, out var result))
         {
             _copyCommand.Text = result;
-            _copyCommand.Name = "Copy";
+            _copyCommand.Name = string.IsNullOrWhiteSpace(query) ? string.Empty : "Copy";
             Title = result;
 
             // we have to make the subtitle the equation,

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CmdPal.Ext.Calc;
 
 public partial class CalculatorCommandProvider : CommandProvider
 {
-    // private readonly CalculatorTopLevelListItem calculatorCommand = new();
     private readonly ListItem _listItem = new(new CalculatorListPage()) { Subtitle = "Press = to type an equation" };
+    private readonly FallbackCalculatorItem _fallback = new();
 
     public CalculatorCommandProvider()
     {
@@ -24,6 +24,8 @@ public partial class CalculatorCommandProvider : CommandProvider
     }
 
     public override ICommandItem[] TopLevelCommands() => [_listItem];
+
+    public override IFallbackCommandItem[] FallbackCommands() => [_fallback];
 }
 
 // todo
@@ -87,15 +89,14 @@ public sealed partial class CalculatorListPage : DynamicListPage
         }
         else
         {
-            firstItem.TextToSuggest = ParseQuery(newSearch, out var result) ? result : string.Empty;
+            _copyContextCommand.Text = ParseQuery(newSearch, out var result) ? result : string.Empty;
             firstItem.Title = result;
             firstItem.Subtitle = newSearch;
-            _copyContextCommand.Text = result;
             firstItem.MoreCommands = [_copyContextMenuItem];
         }
     }
 
-    private bool ParseQuery(string equation, out string result)
+    internal static bool ParseQuery(string equation, out string result)
     {
         try
         {
@@ -127,5 +128,43 @@ public sealed partial class SaveCommand : InvokableCommand
     {
         SaveRequested?.Invoke(this, this);
         return CommandResult.KeepOpen();
+    }
+}
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "This is sample code")]
+internal sealed partial class FallbackCalculatorItem : FallbackCommandItem
+{
+    private readonly CopyTextCommand _copyCommand = new(string.Empty);
+
+    public FallbackCalculatorItem()
+        : base(new NoOpCommand())
+    {
+        Command = _copyCommand;
+        _copyCommand.Name = string.Empty;
+        Title = string.Empty;
+        Subtitle = "Type an equation...";
+        Icon = new IconInfo("\ue8ef"); // Calculator
+    }
+
+    public override void UpdateQuery(string query)
+    {
+        if (CalculatorListPage.ParseQuery(query, out var result))
+        {
+            _copyCommand.Text = result;
+            _copyCommand.Name = "Copy";
+            Title = result;
+
+            // we have to make the subtitle the equation,
+            // so that we will still string match the original query
+            // Otherwise, something like 1+2 will have a title of "3" and not match
+            Subtitle = query;
+        }
+        else
+        {
+            _copyCommand.Text = string.Empty;
+            _copyCommand.Name = string.Empty;
+            Title = string.Empty;
+            Subtitle = string.Empty;
+        }
     }
 }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.ClipboardHistory/Commands/PasteCommand.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.ClipboardHistory/Commands/PasteCommand.cs
@@ -62,7 +62,6 @@ internal sealed partial class PasteCommand : InvokableCommand
         HideWindow();
         ClipboardHelper.SendPasteKeyCombination();
         Clipboard.DeleteItemFromHistory(_clipboardItem.Item);
-        CommandResult.ShowToast("Pasting.");
-        return CommandResult.Dismiss();
+        return CommandResult.ShowToast("Pasting");
     }
 }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
@@ -5,20 +5,13 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Models;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
-using Microsoft.UI.Dispatching;
-using Microsoft.UI.Xaml;
 using Microsoft.Win32;
 using Windows.ApplicationModel.DataTransfer;
-using Windows.ApplicationModel.Store;
-using Windows.Storage.Streams;
 
 namespace Microsoft.CmdPal.Ext.ClipboardHistory.Pages;
 
@@ -29,7 +22,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
 
     public ClipboardHistoryListPage()
     {
-        clipboardHistory = new ObservableCollection<ClipboardItem>();
+        clipboardHistory = [];
         _defaultIconPath = string.Empty;
         Icon = new("\uF0E3"); // ClipboardList icon
         Name = "Clipboard History";
@@ -39,10 +32,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         Clipboard.HistoryChanged += TrackClipboardHistoryChanged_EventHandler;
     }
 
-    private void TrackClipboardHistoryChanged_EventHandler(object sender, ClipboardHistoryChangedEventArgs e)
-    {
-        RaiseItemsChanged(0);
-    }
+    private void TrackClipboardHistoryChanged_EventHandler(object sender, ClipboardHistoryChangedEventArgs e) => RaiseItemsChanged(0);
 
     private bool IsClipboardHistoryEnabled()
     {
@@ -83,7 +73,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
     {
         try
         {
-            List<ClipboardItem> items = new();
+            List<ClipboardItem> items = [];
 
             if (!Clipboard.IsHistoryEnabled())
             {
@@ -115,7 +105,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
             {
                 if (item.Item.Content.Contains(StandardDataFormats.Bitmap))
                 {
-                    RandomAccessStreamReference imageReceived = await item.Item.Content.GetBitmapAsync();
+                    var imageReceived = await item.Item.Content.GetBitmapAsync();
 
                     if (imageReceived != null)
                     {
@@ -130,8 +120,8 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         {
             // TODO GH #108 We need to figure out some logging
             // Logger.LogError("Loading clipboard history failed", ex);
-            Debug.WriteLine("Loading clipboard history failed");
-            Debug.WriteLine(ex.ToString());
+            ExtensionHost.ShowStatus(new StatusMessage() { Message = "Loading clipboard history failed", State = MessageState.Error });
+            ExtensionHost.LogMessage(ex.ToString());
         }
     }
 
@@ -140,7 +130,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         // https://github.com/microsoft/windows-rs/issues/317
         // Clipboard API needs to be called in STA or it
         // hangs.
-        Thread thread = new Thread(() =>
+        var thread = new Thread(() =>
         {
             var t = LoadClipboardHistoryAsync();
             t.ConfigureAwait(false);
@@ -154,18 +144,18 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
     private ListItem[] GetClipboardHistoryListItems()
     {
         LoadClipboardHistoryInSTA();
-        ListItem[] listItems = new ListItem[clipboardHistory.Count];
+        List<ListItem> listItems = [];
         for (var i = 0; i < clipboardHistory.Count; i++)
         {
             var item = clipboardHistory[i];
-            listItems[i] = item.ToListItem();
+            if (item != null)
+            {
+                listItems.Add(item.ToListItem());
+            }
         }
 
-        return listItems;
+        return listItems.ToArray();
     }
 
-    public override IListItem[] GetItems()
-    {
-        return GetClipboardHistoryListItems();
-    }
+    public override IListItem[] GetItems() => GetClipboardHistoryListItems();
 }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
@@ -26,7 +26,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         _defaultIconPath = string.Empty;
         Icon = new("\uF0E3"); // ClipboardList icon
         Name = "Clipboard History";
-        Id = "com.microsoft.cmdpal.clipboardhistory";
+        Id = "com.microsoft.cmdpal.clipboardHistory";
         ShowDetails = true;
 
         Clipboard.HistoryChanged += TrackClipboardHistoryChanged_EventHandler;

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
@@ -33,6 +33,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         _defaultIconPath = string.Empty;
         Icon = new("\uF0E3"); // ClipboardList icon
         Name = "Clipboard History";
+        Id = "com.microsoft.cmdpal.clipboardhistory";
         ShowDetails = true;
 
         Clipboard.HistoryChanged += TrackClipboardHistoryChanged_EventHandler;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
@@ -30,13 +30,17 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
 
     // This is set from the SearchBar
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowSuggestion))]
     public partial string Filter { get; set; } = string.Empty;
 
     [ObservableProperty]
     public virtual partial string PlaceholderText { get; private set; } = "Type here to search...";
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowSuggestion))]
     public virtual partial string TextToSuggest { get; protected set; } = string.Empty;
+
+    public bool ShowSuggestion => !string.IsNullOrEmpty(TextToSuggest) && TextToSuggest != Filter;
 
     [ObservableProperty]
     public partial CommandPaletteHost ExtensionHost { get; private set; }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ToastViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ToastViewModel.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class ToastViewModel : ObservableObject
+{
+    [ObservableProperty]
+    public partial string ToastMessage { get; set; } = string.Empty;
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml
@@ -44,7 +44,7 @@
             BorderBrush="{ThemeResource TextFillColorSecondaryBrush}"
             BorderThickness="1"
             CornerRadius="4"
-            Visibility="{x:Bind CurrentPageViewModel.TextToSuggest, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}">
+            Visibility="{x:Bind CurrentPageViewModel.ShowSuggestion, Mode=OneWay}">
             <FontIcon
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
@@ -59,6 +59,6 @@
             VerticalAlignment="Stretch"
             Foreground="{ThemeResource TextControlPlaceholderForeground}"
             Text="{x:Bind CurrentPageViewModel.TextToSuggest, Mode=OneWay}"
-            Visibility="{x:Bind CurrentPageViewModel.TextToSuggest, Converter={StaticResource StringNotEmptyToVisibilityConverter}, Mode=OneWay}" />
+            Visibility="{x:Bind CurrentPageViewModel.ShowSuggestion, Mode=OneWay}" />
     </StackPanel>
 </UserControl>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
@@ -10,6 +10,7 @@ SetWindowLongPtr
 CallWindowProc
 ShowWindow
 SetForegroundWindow
+EnableWindow
 SetFocus
 SetActiveWindow
 MonitorFromWindow

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml
@@ -46,9 +46,7 @@
 
                     <TextBlock x:Uid="ExtensionCommandsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
 
-                    <ItemsRepeater 
-                        ItemsSource="{x:Bind ViewModel.TopLevelCommands, Mode=OneWay}" 
-                        Layout="{StaticResource VerticalStackLayout}">
+                    <ItemsRepeater ItemsSource="{x:Bind ViewModel.TopLevelCommands, Mode=OneWay}" Layout="{StaticResource VerticalStackLayout}">
                         <ItemsRepeater.ItemTemplate>
                             <DataTemplate x:DataType="viewmodels:TopLevelViewModel">
                                 <controls:SettingsExpander
@@ -82,7 +80,7 @@
                             </DataTemplate>
                         </ItemsRepeater.ItemTemplate>
                     </ItemsRepeater>
-                    
+
                     <TextBlock
                         x:Uid="ExtensionSettingsHeader"
                         Style="{StaticResource SettingsSectionHeaderTextBlockStyle}"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -235,9 +235,9 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
                     case CommandResultKind.ShowToast:
                         {
-                            _toast.AppWindow.Show();
                             if (result.Args is IToastArgs a)
                             {
+                                _toast.ShowToast(a.Message);
                                 HandleCommandResult(a.Result);
                             }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -43,6 +43,8 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
     private readonly SlideNavigationTransitionInfo _slideRightTransition = new() { Effect = SlideNavigationTransitionEffect.FromRight };
     private readonly SuppressNavigationTransitionInfo _noAnimation = new();
 
+    private readonly ToastWindow _toast = new();
+
     public ShellViewModel ViewModel { get; private set; } = App.Current.Services.GetService<ShellViewModel>()!;
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -228,6 +230,17 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
                     case CommandResultKind.KeepOpen:
                         {
                             // Do nothing.
+                            break;
+                        }
+
+                    case CommandResultKind.ShowToast:
+                        {
+                            _toast.AppWindow.Show();
+                            if (result.Args is IToastArgs a)
+                            {
+                                HandleCommandResult(a.Result);
+                            }
+
                             break;
                         }
                 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Window
+    x:Class="Microsoft.CmdPal.UI.ToastWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:Microsoft.CmdPal.UI"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    Title="Command Palette Toast"
+    mc:Ignorable="d">
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+    <Grid>
+        <TextBlock
+            x:Name="ToastText"
+            Margin="20"
+            Text="Test toast"
+            TextWrapping="Wrap"
+            TextAlignment="Center"
+            FontSize="20"
+            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+    </Grid>
+</Window>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
@@ -12,14 +12,14 @@
     <Window.SystemBackdrop>
         <MicaBackdrop />
     </Window.SystemBackdrop>
-    <Grid>
+    <StackPanel x:Name="ToastGrid">
         <TextBlock
             x:Name="ToastText"
-            Margin="20"
-            Text="Test toast"
-            TextWrapping="Wrap"
-            TextAlignment="Center"
-            FontSize="20"
+            Padding="8,8,28,20"
+            Text="{x:Bind ViewModel.ToastMessage, Mode=OneWay}"
+            
+            TextAlignment="Left"
+            FontSize="16"
             Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" />
-    </Grid>
+    </StackPanel>
 </Window>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
@@ -7,11 +7,12 @@
     xmlns:local="using:Microsoft.CmdPal.UI"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="using:CommunityToolkit.WinUI"
+    Activated="OnActivated"
     Title="Command Palette Toast"
     mc:Ignorable="d">
-    <Window.SystemBackdrop>
+    <!--<Window.SystemBackdrop>
         <MicaBackdrop />
-    </Window.SystemBackdrop>
+    </Window.SystemBackdrop>-->
     <StackPanel x:Name="ToastGrid">
         <TextBlock
             x:Name="ToastText"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <Window
     x:Class="Microsoft.CmdPal.UI.ToastWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -7,8 +7,8 @@
     xmlns:local="using:Microsoft.CmdPal.UI"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="using:CommunityToolkit.WinUI"
-    Activated="OnActivated"
     Title="Command Palette Toast"
+    Activated="OnActivated"
     mc:Ignorable="d">
     <!--<Window.SystemBackdrop>
         <MicaBackdrop />
@@ -17,10 +17,9 @@
         <TextBlock
             x:Name="ToastText"
             Padding="8,8,28,20"
-            Text="{x:Bind ViewModel.ToastMessage, Mode=OneWay}"
-            
-            TextAlignment="Left"
             FontSize="16"
-            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+            Text="{x:Bind ViewModel.ToastMessage, Mode=OneWay}"
+            TextAlignment="Left" />
     </StackPanel>
 </Window>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
@@ -2,6 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using CommunityToolkit.WinUI;
+using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Windows.Graphics;
@@ -10,28 +13,62 @@ namespace Microsoft.CmdPal.UI;
 
 public sealed partial class ToastWindow : Window
 {
+    public ToastViewModel ViewModel { get; } = new();
+
+    private readonly DispatcherQueueTimer _debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+
     public ToastWindow()
     {
         this.InitializeComponent();
-        this.ExtendsContentIntoTitleBar = true;
-        this.AppWindow.Hide();
-        this.AppWindow.IsShownInSwitchers = false;
-        this.AppWindow.SetIcon("ms-appx:///Assets/Icons/StoreLogo.png");
-        this.AppWindow.Title = "Command Palette Settings";
-        this.AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
-        PositionCentered();
+        AppWindow.Hide();
+        AppWindow.IsShownInSwitchers = false;
+        ExtendsContentIntoTitleBar = true;
+        AppWindow.SetPresenter(AppWindowPresenterKind.CompactOverlay);
+        AppWindow.SetIcon("ms-appx:///Assets/Icons/StoreLogo.png");
+        AppWindow.Title = "Command Palette Settings";
+        AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
+
+        // PositionCentered();
     }
 
     private void PositionCentered()
     {
-        AppWindow.Resize(new SizeInt32 { Width = 1280, Height = 32 });
+        // AppWindow.Resize(new SizeInt32 { Width = 1280, Height = 32 });
+
+        // var floatSize = ToastText.ActualSize.ToSize();
+        var intSize = new SizeInt32 { Width = Convert.ToInt32(ToastText.ActualWidth), Height = Convert.ToInt32(ToastText.ActualHeight) };
+        AppWindow.Resize(intSize);
+
         var displayArea = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Nearest);
         if (displayArea is not null)
         {
             var centeredPosition = AppWindow.Position;
             centeredPosition.X = (displayArea.WorkArea.Width - AppWindow.Size.Width) / 2;
-            centeredPosition.Y = (int)((displayArea.WorkArea.Height - AppWindow.Size.Height) * .75);
+
+            var monitorHeight = displayArea.WorkArea.Height;
+            var windowHeight = AppWindow.Size.Height;
+            centeredPosition.Y = (int)(monitorHeight - (windowHeight * 2));
             AppWindow.Move(centeredPosition);
         }
+    }
+
+    public void ShowToast(string message)
+    {
+        ViewModel.ToastMessage = message;
+        DispatcherQueue.TryEnqueue(
+            DispatcherQueuePriority.Low,
+            () =>
+        {
+            PositionCentered();
+            AppWindow.Show();
+
+            _debounceTimer.Debounce(
+                () =>
+                {
+                    AppWindow.Hide();
+                },
+                interval: TimeSpan.FromMilliseconds(2500),
+                immediate: false);
+        });
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Windows.Graphics;
+
+namespace Microsoft.CmdPal.UI;
+
+public sealed partial class ToastWindow : Window
+{
+    public ToastWindow()
+    {
+        this.InitializeComponent();
+        this.ExtendsContentIntoTitleBar = true;
+        this.AppWindow.Hide();
+        this.AppWindow.IsShownInSwitchers = false;
+        this.AppWindow.SetIcon("ms-appx:///Assets/Icons/StoreLogo.png");
+        this.AppWindow.Title = "Command Palette Settings";
+        this.AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
+        PositionCentered();
+    }
+
+    private void PositionCentered()
+    {
+        AppWindow.Resize(new SizeInt32 { Width = 1280, Height = 32 });
+        var displayArea = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Nearest);
+        if (displayArea is not null)
+        {
+            var centeredPosition = AppWindow.Position;
+            centeredPosition.X = (displayArea.WorkArea.Width - AppWindow.Size.Width) / 2;
+            centeredPosition.Y = (int)((displayArea.WorkArea.Height - AppWindow.Size.Height) * .75);
+            AppWindow.Move(centeredPosition);
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
@@ -8,11 +8,16 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Windows.Graphics;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Microsoft.CmdPal.UI;
 
 public sealed partial class ToastWindow : Window
 {
+    private readonly HWND _hwnd;
+
     public ToastViewModel ViewModel { get; } = new();
 
     private readonly DispatcherQueueTimer _debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
@@ -27,6 +32,9 @@ public sealed partial class ToastWindow : Window
         AppWindow.SetIcon("ms-appx:///Assets/Icons/StoreLogo.png");
         AppWindow.Title = "Command Palette Settings";
         AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
+
+        _hwnd = new HWND(WinRT.Interop.WindowNative.GetWindowHandle(this).ToInt32());
+        PInvoke.EnableWindow(_hwnd, false);
 
         // PositionCentered();
     }
@@ -60,7 +68,9 @@ public sealed partial class ToastWindow : Window
             () =>
         {
             PositionCentered();
-            AppWindow.Show();
+
+            // AppWindow.Show();
+            PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_SHOWNA);
 
             _debounceTimer.Debounce(
                 () =>

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CopyTextCommand.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CopyTextCommand.cs
@@ -8,7 +8,7 @@ public partial class CopyTextCommand : InvokableCommand
 {
     public string Text { get; set; }
 
-    public CommandResult Result { get; set; } = CommandResult.Dismiss();
+    public CommandResult Result { get; set; } = CommandResult.ShowToast("Copied to clipboard");
 
     public CopyTextCommand(string text)
     {


### PR DESCRIPTION
Well, I started by wanting to just close #385. Then I thought, "well, the copy command really needs that toast, doesn't it"

one thing lead to another, and now

![clipboard-history-toast](https://github.com/user-attachments/assets/4d84225c-17bd-4b42-9587-6411888db922)

Closes #385
Closes # what I never filed `ShowToast`, from https://github.com/zadjii-msft/PowerToys/pull/395