### PR TITLE
Add edit & delete to Bookmarks

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkForm.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkForm.cs
@@ -4,54 +4,56 @@
 
 using System;
 using System.IO;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.Foundation;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-internal sealed partial class AddBookmarkForm : Form
+internal sealed partial class AddBookmarkForm : FormContent
 {
     internal event TypedEventHandler<object, object?>? AddedCommand;
 
-    public override string TemplateJson()
+    public AddBookmarkForm(string name = "", string url = "")
     {
-        var json = $$"""
+        TemplateJson = $$"""
 {
     "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
     "type": "AdaptiveCard",
     "version": "1.5",
     "body": [
         {
-        "type": "Input.Text",
-        "style": "text",
-        "id": "name",
-        "label": "Name",
-        "isRequired": true,
-        "errorMessage": "Name is required"
+            "type": "Input.Text",
+            "style": "text",
+            "id": "name",
+            "label": "Name",
+            "value": {{JsonSerializer.Serialize(name)}},
+            "isRequired": true,
+            "errorMessage": "Name is required"
         },
         {
-        "type": "Input.Text",
-        "style": "text",
-        "id": "bookmark",
-        "label": "URL or File Path",
-        "isRequired": true,
-        "errorMessage": "URL or File Path is required"
+            "type": "Input.Text",
+            "style": "text",
+            "id": "bookmark",
+            "value": {{JsonSerializer.Serialize(url)}},
+            "label": "URL or File Path",
+            "isRequired": true,
+            "errorMessage": "URL or File Path is required"
         }
     ],
     "actions": [
         {
-        "type": "Action.Submit",
-        "title": "Save",
-        "data": {
-            "name": "name",
-            "bookmark": "bookmark"
-        }
+            "type": "Action.Submit",
+            "title": "Save",
+            "data": {
+                "name": "name",
+                "bookmark": "bookmark"
+            }
         }
     ]
 }
 """;
-        return json;
     }
 
     public override CommandResult SubmitForm(string payload)

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkPage.cs
@@ -8,9 +8,9 @@ using Windows.Foundation;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-internal sealed partial class AddBookmarkPage : FormPage
+internal sealed partial class AddBookmarkPage : ContentPage
 {
-    private readonly AddBookmarkForm _addBookmark = new();
+    private readonly AddBookmarkForm _addBookmark;
 
     internal event TypedEventHandler<object, object?>? AddedCommand
     {
@@ -18,11 +18,14 @@ internal sealed partial class AddBookmarkPage : FormPage
         remove => _addBookmark.AddedCommand -= value;
     }
 
-    public override IForm[] Forms() => [_addBookmark];
+    public override IContent[] GetContent() => [_addBookmark];
 
-    public AddBookmarkPage()
+    public AddBookmarkPage(string name = "", string url = "")
     {
-        this.Icon = new IconInfo("\ued0e");
-        this.Name = "Add a Bookmark";
+        Icon = new IconInfo("\ued0e");
+        var isAdd = string.IsNullOrEmpty(name) && string.IsNullOrEmpty(url);
+        Title = isAdd ? "Add a bookmark" : "Edit bookmark";
+        Name = isAdd ? "Add bookmark" : "Edit bookmark";
+        _addBookmark = new(name, url);
     }
 }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkData.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkData.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text.Json.Serialization;
+
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
 public class BookmarkData
@@ -11,4 +13,7 @@ public class BookmarkData
     public string Bookmark { get; set; } = string.Empty;
 
     public string Type { get; set; } = string.Empty;
+
+    [JsonIgnore]
+    public bool IsPlaceholder => Bookmark.Contains('{') && Bookmark.Contains('}');
 }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderForm.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderForm.cs
@@ -12,7 +12,7 @@ using Windows.System;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-internal sealed partial class BookmarkPlaceholderForm : Form
+internal sealed partial class BookmarkPlaceholderForm : FormContent
 {
     private readonly List<string> _placeholderNames;
 
@@ -22,13 +22,9 @@ internal sealed partial class BookmarkPlaceholderForm : Form
     public BookmarkPlaceholderForm(string name, string url, string type)
     {
         _bookmark = url;
-        Regex r = new Regex(Regex.Escape("{") + "(.*?)" + Regex.Escape("}"));
-        MatchCollection matches = r.Matches(url);
+        var r = new Regex(Regex.Escape("{") + "(.*?)" + Regex.Escape("}"));
+        var matches = r.Matches(url);
         _placeholderNames = matches.Select(m => m.Groups[1].Value).ToList();
-    }
-
-    public override string TemplateJson()
-    {
         var inputs = _placeholderNames.Select(p =>
         {
             return $$"""
@@ -45,7 +41,7 @@ internal sealed partial class BookmarkPlaceholderForm : Form
 
         var allInputs = string.Join(",", inputs);
 
-        var json = $$"""
+        TemplateJson = $$"""
 {
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
   "type": "AdaptiveCard",
@@ -64,7 +60,6 @@ internal sealed partial class BookmarkPlaceholderForm : Form
   ]
 }
 """;
-        return json;
     }
 
     public override CommandResult SubmitForm(string payload)
@@ -88,7 +83,7 @@ internal sealed partial class BookmarkPlaceholderForm : Form
 
         try
         {
-            Uri? uri = UrlCommand.GetUri(target);
+            var uri = UrlCommand.GetUri(target);
             if (uri != null)
             {
                 _ = Launcher.LaunchUriAsync(uri);

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderPage.cs
@@ -13,6 +13,11 @@ internal sealed partial class BookmarkPlaceholderPage : FormPage
 
     public override IForm[] Forms() => [_bookmarkPlaceholder];
 
+    public BookmarkPlaceholderPage(BookmarkData data)
+        : this(data.Name, data.Bookmark, data.Type)
+    {
+    }
+
     public BookmarkPlaceholderPage(string name, string url, string type)
     {
         Name = name;

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderPage.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderPage.cs
@@ -7,11 +7,11 @@ using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks;
 
-internal sealed partial class BookmarkPlaceholderPage : FormPage
+internal sealed partial class BookmarkPlaceholderPage : ContentPage
 {
-    private readonly IForm _bookmarkPlaceholder;
+    private readonly FormContent _bookmarkPlaceholder;
 
-    public override IForm[] Forms() => [_bookmarkPlaceholder];
+    public override IContent[] GetContent() => [_bookmarkPlaceholder];
 
     public BookmarkPlaceholderPage(BookmarkData data)
         : this(data.Name, data.Bookmark, data.Type)

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarksCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Bookmark/BookmarksCommandProvider.cs
@@ -86,20 +86,20 @@ public partial class BookmarksCommandProvider : CommandProvider
         contextMenu.Add(new CommandContextItem(edit));
 
         var delete = new CommandContextItem(
-            () =>
-        {
-            if (_bookmarks != null)
-            {
-                _bookmarks.Data.Remove(bookmark);
-                var jsonPath = BookmarksCommandProvider.StateJsonPath();
-                Bookmarks.WriteToFile(jsonPath, _bookmarks);
-                _commands.Clear();
-                LoadCommands();
-                RaiseItemsChanged(0);
-            }
-        },
             title: "Delete bookmark",
             name: "Delete",
+            action: () =>
+            {
+                if (_bookmarks != null)
+                {
+                    _bookmarks.Data.Remove(bookmark);
+                    var jsonPath = BookmarksCommandProvider.StateJsonPath();
+                    Bookmarks.WriteToFile(jsonPath, _bookmarks);
+                    _commands.Clear();
+                    LoadCommands();
+                    RaiseItemsChanged(0);
+                }
+            },
             result: CommandResult.KeepOpen())
         {
             IsCritical = true,

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
@@ -53,7 +53,7 @@ public sealed partial class CalculatorListPage : DynamicListPage
         _copyContextCommand = new CopyTextCommand(string.Empty);
         _copyContextMenuItem = new CommandContextItem(_copyContextCommand);
 
-        _items.Add(new(_saveCommand));
+        _items.Add(new(_saveCommand) { Icon = new IconInfo("\uE94E") });
 
         UpdateSearchText(string.Empty, string.Empty);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -42,7 +42,8 @@ public sealed partial class ListPage : Page,
             ViewModel = lvm;
         }
 
-        if (e.NavigationMode == NavigationMode.Back)
+        if (e.NavigationMode == NavigationMode.Back
+            || (e.NavigationMode == NavigationMode.New && ItemsList.Items.Count > 0))
         {
             // Upon navigating _back_ to this page, immediately select the
             // first item in the list

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/AnonymousCommand.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/AnonymousCommand.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+public sealed partial class AnonymousCommand : InvokableCommand
+{
+    private readonly Action _action;
+
+    public ICommandResult Result { get; set; } = CommandResult.Dismiss();
+
+    public AnonymousCommand(Action action)
+    {
+        Name = "Invoke";
+        _action = action;
+    }
+
+    public override ICommandResult Invoke()
+    {
+        _action();
+        return Result;
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/AnonymousCommand.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/AnonymousCommand.cs
@@ -6,11 +6,11 @@ namespace Microsoft.CommandPalette.Extensions.Toolkit;
 
 public sealed partial class AnonymousCommand : InvokableCommand
 {
-    private readonly Action _action;
+    private readonly Action? _action;
 
     public ICommandResult Result { get; set; } = CommandResult.Dismiss();
 
-    public AnonymousCommand(Action action)
+    public AnonymousCommand(Action? action)
     {
         Name = "Invoke";
         _action = action;
@@ -18,7 +18,11 @@ public sealed partial class AnonymousCommand : InvokableCommand
 
     public override ICommandResult Invoke()
     {
-        _action();
+        if (_action != null)
+        {
+            _action();
+        }
+
         return Result;
     }
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandContextItem.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandContextItem.cs
@@ -14,4 +14,28 @@ public partial class CommandContextItem : CommandItem, ICommandContextItem
         : base(command)
     {
     }
+
+    public CommandContextItem(
+        Action action,
+        string title,
+        string subtitle = "",
+        string name = "",
+        ICommandResult? result = null)
+    {
+        var c = new AnonymousCommand(action);
+        if (!string.IsNullOrEmpty(name))
+        {
+            c.Name = name;
+        }
+
+        if (result != null)
+        {
+            c.Result = result;
+        }
+
+        Command = c;
+
+        Title = title;
+        Subtitle = subtitle;
+    }
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandContextItem.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandContextItem.cs
@@ -16,10 +16,10 @@ public partial class CommandContextItem : CommandItem, ICommandContextItem
     }
 
     public CommandContextItem(
-        Action action,
         string title,
         string subtitle = "",
         string name = "",
+        Action? action = null,
         ICommandResult? result = null)
     {
         var c = new AnonymousCommand(action);

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandItem.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandItem.cs
@@ -65,6 +65,11 @@ public partial class CommandItem : BaseObservable, ICommandItem
 
 = [];
 
+    public CommandItem()
+        : this(new NoOpCommand())
+    {
+    }
+
     public CommandItem(ICommand command)
     {
         Command = command;
@@ -78,5 +83,29 @@ public partial class CommandItem : BaseObservable, ICommandItem
         Subtitle = other.Subtitle;
         Icon = (IconInfo?)other.Icon;
         MoreCommands = other.MoreCommands;
+    }
+
+    public CommandItem(
+        Action action,
+        string title,
+        string subtitle = "",
+        string name = "",
+        ICommandResult? result = null)
+    {
+        var c = new AnonymousCommand(action);
+        if (!string.IsNullOrEmpty(name))
+        {
+            c.Name = name;
+        }
+
+        if (result != null)
+        {
+            c.Result = result;
+        }
+
+        Command = c;
+
+        Title = title;
+        Subtitle = subtitle;
     }
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandItem.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandItem.cs
@@ -86,10 +86,10 @@ public partial class CommandItem : BaseObservable, ICommandItem
     }
 
     public CommandItem(
-        Action action,
         string title,
         string subtitle = "",
         string name = "",
+        Action? action = null,
         ICommandResult? result = null)
     {
         var c = new AnonymousCommand(action);

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Bookmark/UrlCommand.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Bookmark/UrlCommand.cs
@@ -10,29 +10,29 @@ namespace Microsoft.CmdPal.Ext.Bookmarks;
 
 public partial class UrlCommand : InvokableCommand
 {
-    private bool IsContainsPlaceholder => _url.Contains('{') && _url.Contains('}');
-
     public string Type { get; }
 
     public string Url { get; }
 
-    private readonly string _url;
+    public UrlCommand(BookmarkData data)
+        : this(data.Name, data.Bookmark, data.Type)
+    {
+    }
 
     public UrlCommand(string name, string url, string type)
     {
-        _url = url;
-        Icon = new IconInfo(IconFromUrl(_url, type));
         Name = name;
         Type = type;
         Url = url;
+        Icon = new IconInfo(IconFromUrl(Url, type));
     }
 
     public override CommandResult Invoke()
     {
-        var target = _url;
+        var target = Url;
         try
         {
-            Uri? uri = GetUri(target);
+            var uri = GetUri(target);
             if (uri != null)
             {
                 _ = Launcher.LaunchUriAsync(uri);
@@ -79,7 +79,7 @@ public partial class UrlCommand : InvokableCommand
                 var baseString = placeholderIndex > 0 ? url.Substring(0, placeholderIndex) : url;
                 try
                 {
-                    Uri? uri = GetUri(baseString);
+                    var uri = GetUri(baseString);
                     if (uri != null)
                     {
                         var hostname = uri.Host;


### PR DESCRIPTION
Re-write the bookmarks extension, to add support for edit and delete commands. This is one of the older extensions in the codebase so it was quite dated. Along the way:

* Resolved a COM threading issue with `CommandResults` (which I never saw before?)
* Also a really good idea I just had: `AnonymousCommand`s, so you can just pass a lambda to a CommandItem and that's the whole command. Don't need to define a whole command class just for that.
* Drive-by:
  * Closes #251
  * Closes #344 