### PR TITLE
[Search files] Loading more items fix

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -271,6 +271,14 @@ public partial class ListViewModel : PageViewModel
         listPage.ItemsChanged += Model_ItemsChanged;
     }
 
+    public void LoadMoreIfNeeded()
+    {
+        if (_model.Unsafe?.HasMoreItems ?? false)
+        {
+            _model.Unsafe.LoadMore();
+        }
+    }
+
     protected override void FetchProperty(string propertyName)
     {
         base.FetchProperty(propertyName);

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Indexer/Indexer/SearchQuery.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Indexer/Indexer/SearchQuery.cs
@@ -194,6 +194,12 @@ internal sealed partial class SearchQuery : IDisposable
             return false;
         }
 
+        if (currentRowset is not IGetRow)
+        {
+            Logger.LogInfo("Reset the current rowset");
+            ExecuteSyncInternal();
+        }
+
         if (currentRowset is not IGetRow getRow)
         {
             Logger.LogError("Rowset does not support IGetRow interface");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

A fix for the issue that not all results in file search are shown when scrolling to the bottom. 

* Added a request to load new items when the user scrolls to the bottom
* Re-request items when facing an error in the file search to ensure we show all results in the list

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Search something that should get more than 20 results (I usually typed a single letter for testing)
* Scroll down to the bottom and check if new entries are loading.


Closes #351 