### PR TITLE
Implement a basic recently-used-apps algorithm 

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/Microsoft.CmdPal.Ext.Apps.csproj
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Apps/Microsoft.CmdPal.Ext.Apps.csproj
@@ -15,6 +15,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
 
+    <PackageReference Include="WyHash" />
+
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CommandPalette.Extensions.Toolkit\Microsoft.CommandPalette.Extensions.Toolkit.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
@@ -17,11 +17,16 @@ public partial class AppStateModel : ObservableObject
     [JsonIgnore]
     public static readonly string FilePath;
 
+    [JsonIgnore]
+    public RecentCommandsManager RecentCommands { get; }
+
     public event TypedEventHandler<AppStateModel, object?>? StateChanged;
 
     ///////////////////////////////////////////////////////////////////////////
     // STATE HERE
-    public RecentCommandsManager RecentCommands { get; private set; } = new();
+    [JsonInclude]
+    [JsonPropertyName("History")]
+    internal List<HistoryItem> History { get; private set; } = [];
 
     // END SETTINGS
     ///////////////////////////////////////////////////////////////////////////
@@ -29,6 +34,11 @@ public partial class AppStateModel : ObservableObject
     static AppStateModel()
     {
         FilePath = StateJsonPath();
+    }
+
+    private AppStateModel()
+    {
+        RecentCommands = new(this);
     }
 
     public static AppStateModel LoadState()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
@@ -132,5 +132,8 @@ public partial class AppStateModel : ObservableObject
     {
         PropertyNameCaseInsensitive = true,
         IncludeFields = true,
+        AllowTrailingCommas = true,
+        PreferredObjectCreationHandling = JsonObjectCreationHandling.Populate,
+        ReadCommentHandling = JsonCommentHandling.Skip,
     };
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
@@ -17,16 +17,11 @@ public partial class AppStateModel : ObservableObject
     [JsonIgnore]
     public static readonly string FilePath;
 
-    [JsonIgnore]
-    public RecentCommandsManager RecentCommands { get; }
-
     public event TypedEventHandler<AppStateModel, object?>? StateChanged;
 
     ///////////////////////////////////////////////////////////////////////////
     // STATE HERE
-    [JsonInclude]
-    [JsonPropertyName("History")]
-    internal List<HistoryItem> History { get; private set; } = [];
+    public RecentCommandsManager RecentCommands { get; private set; } = new();
 
     // END SETTINGS
     ///////////////////////////////////////////////////////////////////////////
@@ -34,11 +29,6 @@ public partial class AppStateModel : ObservableObject
     static AppStateModel()
     {
         FilePath = StateJsonPath();
-    }
-
-    private AppStateModel()
-    {
-        RecentCommands = new(this);
     }
 
     public static AppStateModel LoadState()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class AppStateModel : ObservableObject
+{
+    [JsonIgnore]
+    public static readonly string FilePath;
+
+    public event TypedEventHandler<AppStateModel, object?>? StateChanged;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // STATE HERE
+    public RecentCommandsManager RecentCommands { get; private set; } = new();
+
+    // END SETTINGS
+    ///////////////////////////////////////////////////////////////////////////
+
+    static AppStateModel()
+    {
+        FilePath = StateJsonPath();
+    }
+
+    public static AppStateModel LoadState()
+    {
+        if (string.IsNullOrEmpty(FilePath))
+        {
+            throw new InvalidOperationException($"You must set a valid {nameof(SettingsModel.FilePath)} before calling {nameof(LoadState)}");
+        }
+
+        if (!File.Exists(FilePath))
+        {
+            Debug.WriteLine("The provided settings file does not exist");
+            return new();
+        }
+
+        try
+        {
+            // Read the JSON content from the file
+            var jsonContent = File.ReadAllText(FilePath);
+
+            var loaded = JsonSerializer.Deserialize<AppStateModel>(jsonContent, _deserializerOptions);
+
+            Debug.WriteLine(loaded != null ? "Loaded settings file" : "Failed to parse");
+
+            return loaded ?? new();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex.ToString());
+        }
+
+        return new();
+    }
+
+    public static void SaveState(AppStateModel model)
+    {
+        if (string.IsNullOrEmpty(FilePath))
+        {
+            throw new InvalidOperationException($"You must set a valid {nameof(FilePath)} before calling {nameof(SaveState)}");
+        }
+
+        try
+        {
+            // Serialize the main dictionary to JSON and save it to the file
+            var settingsJson = JsonSerializer.Serialize(model, _serializerOptions);
+
+            // Is it valid JSON?
+            if (JsonNode.Parse(settingsJson) is JsonObject newSettings)
+            {
+                // Now, read the existing content from the file
+                var oldContent = File.Exists(FilePath) ? File.ReadAllText(FilePath) : "{}";
+
+                // Is it valid JSON?
+                if (JsonNode.Parse(oldContent) is JsonObject savedSettings)
+                {
+                    foreach (var item in newSettings)
+                    {
+                        savedSettings[item.Key] = item.Value != null ? item.Value.DeepClone() : null;
+                    }
+
+                    var serialized = savedSettings.ToJsonString(_serializerOptions);
+                    File.WriteAllText(FilePath, serialized);
+
+                    // TODO: Instead of just raising the event here, we should
+                    // have a file change watcher on the settings file, and
+                    // reload the settings then
+                    model.StateChanged?.Invoke(model, null);
+                }
+                else
+                {
+                    Debug.WriteLine("Failed to parse settings file as JsonObject.");
+                }
+            }
+            else
+            {
+                Debug.WriteLine("Failed to parse settings file as JsonObject.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex.ToString());
+        }
+    }
+
+    internal static string StateJsonPath()
+    {
+        var directory = Utilities.BaseSettingsPath("Microsoft.CmdPal");
+        Directory.CreateDirectory(directory);
+
+        // now, the settings is just next to the exe
+        return Path.Combine(directory, "state.json");
+    }
+
+    private static readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private static readonly JsonSerializerOptions _deserializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        IncludeFields = true,
+    };
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -185,7 +185,7 @@ public partial class MainListPage : DynamicListPage,
         };
         var max = scores.Max();
 
-        var history = _serviceProvider.GetService<RecentCommandsManager>()!;
+        var history = _serviceProvider.GetService<AppStateModel>()!.RecentCommands;
         var recentWeightBoost = history.GetCommandHistoryWeight(id);
 
         var finalScore = (max / (isFallback ? 3 : 1))
@@ -205,8 +205,10 @@ public partial class MainListPage : DynamicListPage,
     public void UpdateHistory(IListItem topLevelOrAppItem)
     {
         var id = IdForTopLevelOrAppItem(topLevelOrAppItem);
-        var history = _serviceProvider.GetService<RecentCommandsManager>()!;
+        var state = _serviceProvider.GetService<AppStateModel>()!;
+        var history = state.RecentCommands;
         history.AddHistoryItem(id);
+        AppStateModel.SaveState(state);
     }
 
     private string IdForTopLevelOrAppItem(IListItem topLevelOrAppItem)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -10,7 +10,6 @@ using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.Extensions.DependencyInjection;
-using WyHash;
 
 namespace Microsoft.CmdPal.UI.ViewModels.MainPage;
 
@@ -194,14 +193,6 @@ public partial class MainListPage : DynamicListPage,
         return finalScore; // but downweight them
     }
 
-    private string GenerateIdForApp(IListItem app)
-    {
-        // Use WyHash64 to generate stable ID hashes.
-        // manually seeding with 0, so that the hash is stable across launches
-        var result = WyHash64.ComputeHash64(app.Title + app.Subtitle, seed: 0);
-        return $"{app.Title}_{result}";
-    }
-
     public void UpdateHistory(IListItem topLevelOrAppItem)
     {
         var id = IdForTopLevelOrAppItem(topLevelOrAppItem);
@@ -220,7 +211,7 @@ public partial class MainListPage : DynamicListPage,
         else
         {
             // we've got an app here
-            return GenerateIdForApp(topLevelOrAppItem);
+            return topLevelOrAppItem.Command?.Id ?? string.Empty;
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/HistoryItem.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/HistoryItem.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public record HistoryItem
+{
+    public required string CommandId { get; set; }
+
+    public required int Uses { get; set; }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -10,8 +10,7 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public partial class RecentCommandsManager : ObservableObject
 {
     [JsonInclude]
-    [JsonPropertyName("History")]
-    private readonly List<HistoryItem> _history = [];
+    private List<HistoryItem> History { get; set; } = [];
 
     public RecentCommandsManager()
     {
@@ -19,7 +18,7 @@ public partial class RecentCommandsManager : ObservableObject
 
     public int GetCommandHistoryWeight(string commandId)
     {
-        var entry = _history
+        var entry = History
             .Index()
             .Where(item => item.Item.CommandId == commandId)
             .FirstOrDefault();
@@ -52,24 +51,24 @@ public partial class RecentCommandsManager : ObservableObject
 
     public void AddHistoryItem(string commandId)
     {
-        var entry = _history
+        var entry = History
             .Where(item => item.CommandId == commandId)
             .FirstOrDefault();
         if (entry == null)
         {
             var newitem = new HistoryItem() { CommandId = commandId, Uses = 1 };
-            _history.Insert(0, newitem);
+            History.Insert(0, newitem);
         }
         else
         {
-            _history.Remove(entry);
+            History.Remove(entry);
             entry.Uses++;
-            _history.Insert(0, entry);
+            History.Insert(0, entry);
         }
 
-        if (_history.Count > 50)
+        if (History.Count > 50)
         {
-            _history.RemoveRange(50, _history.Count);
+            History.RemoveRange(50, History.Count);
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class RecentCommandsManager : ObservableObject
+{
+    private readonly List<HistoryItem> _history = [];
+
+    public RecentCommandsManager()
+    {
+    }
+
+    public int GetCommandHistoryWeight(string commandId)
+    {
+        var entry = _history
+            .Index()
+            .Where(item => item.Item.CommandId == commandId)
+            .FirstOrDefault();
+
+        // These numbers are vaguely scaled so that "VS" will make "Visual Studio" the
+        // match after one use.
+        // Usually it has a weight of 84, compared to 109 for the VS cmd prompt
+        if (entry.Item != null)
+        {
+            var index = entry.Index;
+
+            // First, add some weight based on how early in the list this appears
+            var bucket = index switch
+            {
+                var i when index <= 2 => 35,
+                var i when index <= 10 => 25,
+                var i when index <= 15 => 15,
+                var i when index <= 35 => 10,
+                _ => 5,
+            };
+
+            // Then, add weight for how often this is used, but cap the weight from usage.
+            var uses = Math.Min(entry.Item.Uses * 5, 35);
+
+            return bucket + uses;
+        }
+
+        return 0;
+    }
+
+    public void AddHistoryItem(string commandId)
+    {
+        var entry = _history
+            .Where(item => item.CommandId == commandId)
+            .FirstOrDefault();
+        if (entry == null)
+        {
+            var newitem = new HistoryItem() { CommandId = commandId, Uses = 1 };
+            _history.Insert(0, newitem);
+        }
+        else
+        {
+            _history.Remove(entry);
+            entry.Uses++;
+            _history.Insert(0, entry);
+        }
+
+        if (_history.Count > 50)
+        {
+            _history.RemoveRange(50, _history.Count);
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -2,12 +2,15 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text.Json.Serialization;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
 public partial class RecentCommandsManager : ObservableObject
 {
+    [JsonInclude]
+    [JsonPropertyName("History")]
     private readonly List<HistoryItem> _history = [];
 
     public RecentCommandsManager()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -2,24 +2,24 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text.Json.Serialization;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
 public partial class RecentCommandsManager : ObservableObject
 {
-    [JsonInclude]
-    [JsonPropertyName("History")]
-    private readonly List<HistoryItem> _history = [];
+    private readonly AppStateModel _state;
 
-    public RecentCommandsManager()
+    private List<HistoryItem> History => _state.History;
+
+    public RecentCommandsManager(AppStateModel state)
     {
+        _state = state;
     }
 
     public int GetCommandHistoryWeight(string commandId)
     {
-        var entry = _history
+        var entry = History
             .Index()
             .Where(item => item.Item.CommandId == commandId)
             .FirstOrDefault();
@@ -52,24 +52,24 @@ public partial class RecentCommandsManager : ObservableObject
 
     public void AddHistoryItem(string commandId)
     {
-        var entry = _history
+        var entry = History
             .Where(item => item.CommandId == commandId)
             .FirstOrDefault();
         if (entry == null)
         {
             var newitem = new HistoryItem() { CommandId = commandId, Uses = 1 };
-            _history.Insert(0, newitem);
+            History.Insert(0, newitem);
         }
         else
         {
-            _history.Remove(entry);
+            History.Remove(entry);
             entry.Uses++;
-            _history.Insert(0, entry);
+            History.Insert(0, entry);
         }
 
-        if (_history.Count > 50)
+        if (History.Count > 50)
         {
-            _history.RemoveRange(50, _history.Count);
+            History.RemoveRange(50, History.Count);
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -2,24 +2,24 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text.Json.Serialization;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
 public partial class RecentCommandsManager : ObservableObject
 {
-    private readonly AppStateModel _state;
+    [JsonInclude]
+    [JsonPropertyName("History")]
+    private readonly List<HistoryItem> _history = [];
 
-    private List<HistoryItem> History => _state.History;
-
-    public RecentCommandsManager(AppStateModel state)
+    public RecentCommandsManager()
     {
-        _state = state;
     }
 
     public int GetCommandHistoryWeight(string commandId)
     {
-        var entry = History
+        var entry = _history
             .Index()
             .Where(item => item.Item.CommandId == commandId)
             .FirstOrDefault();
@@ -52,24 +52,24 @@ public partial class RecentCommandsManager : ObservableObject
 
     public void AddHistoryItem(string commandId)
     {
-        var entry = History
+        var entry = _history
             .Where(item => item.CommandId == commandId)
             .FirstOrDefault();
         if (entry == null)
         {
             var newitem = new HistoryItem() { CommandId = commandId, Uses = 1 };
-            History.Insert(0, newitem);
+            _history.Insert(0, newitem);
         }
         else
         {
-            History.Remove(entry);
+            _history.Remove(entry);
             entry.Uses++;
-            History.Insert(0, entry);
+            _history.Insert(0, entry);
         }
 
-        if (History.Count > 50)
+        if (_history.Count > 50)
         {
-            History.RemoveRange(50, History.Count);
+            _history.RemoveRange(50, _history.Count);
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -103,7 +103,7 @@ public partial class App : Application
         services.AddSingleton<TopLevelCommandManager>();
         services.AddSingleton<AliasManager>();
         services.AddSingleton<HotkeyManager>();
-        services.AddSingleton<RecentCommandsManager>();
+        services.AddSingleton<AppStateModel>();
         var sm = SettingsModel.LoadSettings();
         services.AddSingleton(sm);
         services.AddSingleton<IExtensionService, ExtensionService>();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -103,9 +103,10 @@ public partial class App : Application
         services.AddSingleton<TopLevelCommandManager>();
         services.AddSingleton<AliasManager>();
         services.AddSingleton<HotkeyManager>();
-        services.AddSingleton<AppStateModel>();
         var sm = SettingsModel.LoadSettings();
         services.AddSingleton(sm);
+        var state = AppStateModel.LoadState();
+        services.AddSingleton(state);
         services.AddSingleton<IExtensionService, ExtensionService>();
 
         // ViewModels

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -103,6 +103,7 @@ public partial class App : Application
         services.AddSingleton<TopLevelCommandManager>();
         services.AddSingleton<AliasManager>();
         services.AddSingleton<HotkeyManager>();
+        services.AddSingleton<RecentCommandsManager>();
         var sm = SettingsModel.LoadSettings();
         services.AddSingleton(sm);
         services.AddSingleton<IExtensionService, ExtensionService>();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -99,6 +99,12 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
             return;
         }
 
+        if (!RootFrame.CanGoBack)
+        {
+            // on the main page here
+            ViewModel.PerformTopLevelCommand(message);
+        }
+
         // TODO: Actually loading up the page, or invoking the command -
         // that might belong in the model, not the view?
         // Especially considering the try/catch concerns around the fact that the

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Apps/AppCommand.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Apps/AppCommand.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.Apps.Programs;
 using Microsoft.CmdPal.Ext.Apps.Properties;
 using Microsoft.CommandPalette.Extensions.Toolkit;
-using Windows.Storage.Streams;
+using WyHash;
 
 namespace Microsoft.CmdPal.Ext.Apps;
 
@@ -20,6 +20,7 @@ internal sealed partial class AppCommand : InvokableCommand
         _app = app;
 
         Name = Resources.run_command_action;
+        Id = GenerateId();
     }
 
     internal static async Task StartApp(string aumid)
@@ -65,5 +66,13 @@ internal sealed partial class AppCommand : InvokableCommand
     {
         _ = Launch();
         return CommandResult.Dismiss();
+    }
+
+    private string GenerateId()
+    {
+        // Use WyHash64 to generate stable ID hashes.
+        // manually seeding with 0, so that the hash is stable across launches
+        var result = WyHash64.ComputeHash64(_app.Name + _app.Subtitle + _app.ExePath, seed: 0);
+        return $"{_app.Name}_{result}";
     }
 }


### PR DESCRIPTION
This is a very basic frecency implementation, to let MRU apps and commands show up higher in search results. 

Adds support for a `state.json` file, to store this state. Implication is the same as Terminal:
* `settings.json`: These are _your_ settings, take this with you where you go
* `state.json`: this is state _we_ own. You can take it with you at your peril. **We** control this file. 


This seemed good enough to get "VS" to match to "Visual studio" after just a single launch of VS. 

We can iterate on the weighting in the future. 

Closes #317 
This was also half-tracked in closes #147