### PR TITLE
A pair of drive-by bug fixes

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.ClipboardHistory/Commands/CopyCommand.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.ClipboardHistory/Commands/CopyCommand.cs
@@ -2,19 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Resources;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Models;
-using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
-using Windows.ApplicationModel.DataTransfer;
-using Windows.Networking.NetworkOperators;
-using Windows.UI;
 
 namespace Microsoft.CmdPal.Ext.ClipboardHistory.Commands;
 
@@ -41,7 +30,6 @@ internal sealed partial class CopyCommand : InvokableCommand
     public override CommandResult Invoke()
     {
         ClipboardHelper.SetClipboardContent(_clipboardItem, _clipboardFormat);
-        CommandResult.ShowToast("Copied to clipboard");
-        return CommandResult.Dismiss();
+        return CommandResult.ShowToast("Copied to clipboard");
     }
 }

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsTerminal/Helpers/TerminalHelper.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.WindowsTerminal/Helpers/TerminalHelper.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using Microsoft.CmdPal.Ext.WindowsTerminal;
 
 namespace Microsoft.CmdPal.Ext.WindowsTerminal.Helpers;
 
@@ -47,12 +46,13 @@ public static class TerminalHelper
         var options = new JsonDocumentOptions
         {
             CommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
         };
 
         var json = JsonDocument.Parse(settingsJson, options);
         JsonElement profilesList;
 
-        json.RootElement.TryGetProperty("profiles", out JsonElement profilesElement);
+        json.RootElement.TryGetProperty("profiles", out var profilesElement);
         if (profilesElement.ValueKind == JsonValueKind.Object)
         {
             profilesElement.TryGetProperty("list", out profilesList);
@@ -85,16 +85,16 @@ public static class TerminalHelper
     /// <param name="profileElement">Profile from the settings JSON file</param>
     public static TerminalProfile ParseProfile(TerminalPackage terminal, JsonElement profileElement)
     {
-        profileElement.TryGetProperty("name", out JsonElement nameElement);
+        profileElement.TryGetProperty("name", out var nameElement);
         var name = nameElement.ValueKind == JsonValueKind.String ? nameElement.GetString() : null;
 
-        profileElement.TryGetProperty("hidden", out JsonElement hiddenElement);
+        profileElement.TryGetProperty("hidden", out var hiddenElement);
         var hidden = (hiddenElement.ValueKind == JsonValueKind.False || hiddenElement.ValueKind == JsonValueKind.True) && hiddenElement.GetBoolean();
 
-        profileElement.TryGetProperty("guid", out JsonElement guidElement);
+        profileElement.TryGetProperty("guid", out var guidElement);
         var guid = guidElement.ValueKind == JsonValueKind.String ? Guid.Parse(guidElement.GetString()) : null as Guid?;
 
-        profileElement.TryGetProperty("icon", out JsonElement iconElement);
+        profileElement.TryGetProperty("icon", out var iconElement);
         var icon = iconElement.ValueKind == JsonValueKind.String ? iconElement.GetString() : null;
 
         return new TerminalProfile(terminal, name, guid, hidden, icon);


### PR DESCRIPTION
* Allow trailing commas in terminal `settings.json`
* in the Clipboard history copy, actually use the toast message