### PR TITLE
Enable editing aliases in the SUI

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
@@ -11,6 +11,8 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public partial class AliasManager : ObservableObject
 {
     private readonly TopLevelCommandManager _topLevelCommandManager;
+
+    // REMEMBER, CommandAlias.SearchPrefix is what we use as keys
     private readonly Dictionary<string, CommandAlias> _aliases;
 
     public AliasManager(TopLevelCommandManager tlcManager, SettingsModel settings)
@@ -66,5 +68,44 @@ public partial class AliasManager : ObservableObject
             .Where(kv => kv.Value.CommandId == commandId)
             .Select(kv => kv.Value.Alias)
             .FirstOrDefault();
+    }
+
+    public void UpdateAlias(string commandId, string newAliasText)
+    {
+        if (string.IsNullOrEmpty(commandId))
+        {
+            // do nothing?
+            return;
+        }
+
+        if (_aliases.TryGetValue(newAliasText, out var existingAlias))
+        {
+            if (existingAlias.CommandId == commandId)
+            {
+                return;
+            }
+        }
+
+        // Look for the old alias, and remove it
+        List<CommandAlias> toRemove = [];
+        foreach (var kv in _aliases)
+        {
+            if (kv.Value.CommandId == commandId)
+            {
+                toRemove.Add(kv.Value);
+            }
+        }
+
+        foreach (var alias in toRemove)
+        {
+            // REMEMBER, SearchPrefix is what we use as keys
+            _aliases.Remove(alias.SearchPrefix);
+        }
+
+        if (!string.IsNullOrEmpty(newAliasText))
+        {
+            var alias = CommandAlias.FromSearchText(newAliasText, commandId);
+            AddAlias(alias);
+        }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
@@ -70,7 +70,15 @@ public partial class AliasManager : ObservableObject
             .FirstOrDefault();
     }
 
-    public void UpdateAlias(string commandId, string newAliasText)
+    public CommandAlias? AliasFromId(string commandId)
+    {
+        return _aliases
+            .Where(kv => kv.Value.CommandId == commandId)
+            .Select(kv => kv.Value)
+            .FirstOrDefault();
+    }
+
+    public void UpdateAlias(string commandId, CommandAlias? newAlias)
     {
         if (string.IsNullOrEmpty(commandId))
         {
@@ -78,7 +86,9 @@ public partial class AliasManager : ObservableObject
             return;
         }
 
-        if (_aliases.TryGetValue(newAliasText, out var existingAlias))
+        // If we already have _this exact alias_, do nothing
+        if (newAlias != null &&
+            _aliases.TryGetValue(newAlias.SearchPrefix, out var existingAlias))
         {
             if (existingAlias.CommandId == commandId)
             {
@@ -102,10 +112,9 @@ public partial class AliasManager : ObservableObject
             _aliases.Remove(alias.SearchPrefix);
         }
 
-        if (!string.IsNullOrEmpty(newAliasText))
+        if (newAlias != null)
         {
-            var alias = CommandAlias.FromSearchText(newAliasText, commandId);
-            AddAlias(alias);
+            AddAlias(newAlias);
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandAlias.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandAlias.cs
@@ -28,4 +28,11 @@ public class CommandAlias
         : this(string.Empty, string.Empty, false)
     {
     }
+
+    public static CommandAlias FromSearchText(string text, string commandId)
+    {
+        var trailingSpace = text.EndsWith(' ');
+        var realAlias = trailingSpace ? text.Substring(0, text.Length - 1) : text;
+        return new CommandAlias(realAlias, commandId, !trailingSpace);
+    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
@@ -17,7 +17,7 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
     public ExtensionObject<IListItem> Model { get; } = new(model);
 
     [ObservableProperty]
-    public partial ObservableCollection<TagViewModel> Tags { get; set; } = [];
+    public partial Collection<TagViewModel> Tags { get; set; } = [];
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
@@ -17,7 +17,7 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
     public ExtensionObject<IListItem> Model { get; } = new(model);
 
     [ObservableProperty]
-    public partial Collection<TagViewModel> Tags { get; set; } = [];
+    public partial ObservableCollection<TagViewModel> Tags { get; set; } = [];
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
@@ -42,13 +42,8 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
             return; // throw?
         }
 
-        Tags = [.. li.Tags?.Select(t =>
-        {
-            var vm = new TagViewModel(t, PageContext);
-            vm.InitializeProperties();
-            return vm;
-        })
-            .ToList() ?? []];
+        UpdateTags(li.Tags);
+
         TextToSuggest = li.TextToSuggest;
         Section = li.Section ?? string.Empty;
         var extensionDetails = li.Details;
@@ -60,7 +55,6 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
             UpdateProperty(nameof(HasDetails));
         }
 
-        UpdateProperty(nameof(HasTags));
         UpdateProperty(nameof(Tags));
         UpdateProperty(nameof(TextToSuggest));
         UpdateProperty(nameof(Section));
@@ -79,28 +73,7 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
         switch (propertyName)
         {
             case nameof(Tags):
-                var newTags = model.Tags?.Select(t =>
-                {
-                    var vm = new TagViewModel(t, PageContext);
-                    vm.InitializeProperties();
-                    return vm;
-                })
-                    .ToList() ?? [];
-
-                Task.Factory.StartNew(
-                    () =>
-                    {
-                        lock (Tags)
-                        {
-                            ListHelpers.InPlaceUpdateList(Tags, newTags);
-                        }
-
-                        UpdateProperty(nameof(HasTags));
-                    },
-                    CancellationToken.None,
-                    TaskCreationOptions.None,
-                    PageContext.Scheduler);
-
+                UpdateTags(model.Tags);
                 break;
             case nameof(TextToSuggest):
                 this.TextToSuggest = model.TextToSuggest ?? string.Empty;
@@ -128,4 +101,29 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
     public override bool Equals(object? obj) => obj is ListItemViewModel vm && vm.Model.Equals(this.Model);
 
     public override int GetHashCode() => Model.GetHashCode();
+
+    private void UpdateTags(ITag[]? newTagsFromModel)
+    {
+        var newTags = newTagsFromModel?.Select(t =>
+        {
+            var vm = new TagViewModel(t, PageContext);
+            vm.InitializeProperties();
+            return vm;
+        })
+            .ToList() ?? [];
+
+        Task.Factory.StartNew(
+            () =>
+            {
+                lock (Tags)
+                {
+                    ListHelpers.InPlaceUpdateList(Tags, newTags);
+                }
+
+                UpdateProperty(nameof(HasTags));
+            },
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            PageContext.Scheduler);
+    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandItemWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandItemWrapper.cs
@@ -112,6 +112,13 @@ public partial class TopLevelCommandItemWrapper : ListItem
         _generatedId = $"{_commandProviderId}{result}";
     }
 
+    public void UpdateAlias(string newAlias)
+    {
+        _serviceProvider.GetService<AliasManager>()!.UpdateAlias(Id, newAlias);
+        UpdateAlias();
+        UpdateTags();
+    }
+
     private void UpdateAlias()
     {
         // Add tags for the alias, if we have one.

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandItemWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandItemWrapper.cs
@@ -34,7 +34,7 @@ public partial class TopLevelCommandItemWrapper : ListItem
 
     private readonly TopLevelCommandWrapper _topLevelCommand;
 
-    public string? Alias { get; private set; }
+    public CommandAlias? Alias { get; private set; }
 
     private HotkeySettings? _hotkey;
 
@@ -112,7 +112,7 @@ public partial class TopLevelCommandItemWrapper : ListItem
         _generatedId = $"{_commandProviderId}{result}";
     }
 
-    public void UpdateAlias(string newAlias)
+    public void UpdateAlias(CommandAlias? newAlias)
     {
         _serviceProvider.GetService<AliasManager>()!.UpdateAlias(Id, newAlias);
         UpdateAlias();
@@ -125,7 +125,7 @@ public partial class TopLevelCommandItemWrapper : ListItem
         var aliases = _serviceProvider.GetService<AliasManager>();
         if (aliases != null)
         {
-            Alias = aliases.KeysFromId(Id);
+            Alias = aliases.AliasFromId(Id);
         }
     }
 
@@ -148,9 +148,9 @@ public partial class TopLevelCommandItemWrapper : ListItem
             tags.Add(new Tag() { Text = Hotkey.ToString() });
         }
 
-        if (Alias is string keys)
+        if (Alias != null)
         {
-            tags.Add(new Tag() { Text = keys });
+            tags.Add(new Tag() { Text = Alias.SearchPrefix });
         }
 
         this.Tags = tags.ToArray();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -2,12 +2,13 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.CmdPal.UI.ViewModels.Settings;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public sealed class TopLevelViewModel
+public sealed partial class TopLevelViewModel : ObservableObject
 {
     private readonly SettingsModel _settings;
     private readonly IServiceProvider _serviceProvider;
@@ -34,6 +35,26 @@ public sealed class TopLevelViewModel
         }
     }
 
+    public string AliasText
+    {
+        get => field;
+        set
+        {
+            field = value;
+            UpdateAlias();
+        }
+    }
+
+    public bool IsDirectAlias
+    {
+        get => field;
+        set
+        {
+            field = value;
+            UpdateAlias();
+        }
+    }
+
     public TopLevelViewModel(TopLevelCommandItemWrapper item, SettingsModel settings, IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
@@ -42,7 +63,20 @@ public sealed class TopLevelViewModel
         _item = item;
         Icon = new(item.Icon ?? item.Command?.Icon);
         Icon.InitializeProperties();
+
+        var aliases = _serviceProvider.GetService<AliasManager>()!;
+        AliasText = _item.Alias ?? string.Empty;
     }
 
     private void Save() => SettingsModel.SaveSettings(_settings);
+
+    private void UpdateAlias()
+    {
+        var newAliasString = string.IsNullOrWhiteSpace(AliasText) ?
+            string.Empty :
+            AliasText + (IsDirectAlias ? string.Empty : " ");
+
+        _item.UpdateAlias(newAliasString);
+        Save();
+    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -35,15 +35,17 @@ public sealed partial class TopLevelViewModel : ObservableObject
         }
     }
 
-    private string _aliasText = string.Empty;
+    private string _aliasText;
 
     public string AliasText
     {
         get => _aliasText;
         set
         {
-            _aliasText = value;
-            UpdateAlias();
+            if (SetProperty(ref _aliasText, value))
+            {
+                UpdateAlias();
+            }
         }
     }
 
@@ -54,8 +56,10 @@ public sealed partial class TopLevelViewModel : ObservableObject
         get => _isDirectAlias;
         set
         {
-            _isDirectAlias = value;
-            UpdateAlias();
+            if (SetProperty(ref _isDirectAlias, value))
+            {
+                UpdateAlias();
+            }
         }
     }
 
@@ -69,21 +73,21 @@ public sealed partial class TopLevelViewModel : ObservableObject
         Icon.InitializeProperties();
 
         var aliases = _serviceProvider.GetService<AliasManager>()!;
-        _aliasText = _item.Alias?.Alias ?? string.Empty;
         _isDirectAlias = _item.Alias?.IsDirect ?? false;
+        _aliasText = _item.Alias?.Alias ?? string.Empty;
     }
 
     private void Save() => SettingsModel.SaveSettings(_settings);
 
     private void UpdateAlias()
     {
-        if (string.IsNullOrWhiteSpace(AliasText))
+        if (string.IsNullOrWhiteSpace(_aliasText))
         {
             _item.UpdateAlias(null);
         }
         else
         {
-            var newAlias = new CommandAlias(AliasText, _item.Id, IsDirectAlias);
+            var newAlias = new CommandAlias(_aliasText, _item.Id, _isDirectAlias);
             _item.UpdateAlias(newAlias);
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -35,22 +35,26 @@ public sealed partial class TopLevelViewModel : ObservableObject
         }
     }
 
+    private string _aliasText = string.Empty;
+
     public string AliasText
     {
-        get => field;
+        get => _aliasText;
         set
         {
-            field = value;
+            _aliasText = value;
             UpdateAlias();
         }
     }
 
+    private bool _isDirectAlias;
+
     public bool IsDirectAlias
     {
-        get => field;
+        get => _isDirectAlias;
         set
         {
-            field = value;
+            _isDirectAlias = value;
             UpdateAlias();
         }
     }
@@ -65,18 +69,24 @@ public sealed partial class TopLevelViewModel : ObservableObject
         Icon.InitializeProperties();
 
         var aliases = _serviceProvider.GetService<AliasManager>()!;
-        AliasText = _item.Alias ?? string.Empty;
+        _aliasText = _item.Alias?.Alias ?? string.Empty;
+        _isDirectAlias = _item.Alias?.IsDirect ?? false;
     }
 
     private void Save() => SettingsModel.SaveSettings(_settings);
 
     private void UpdateAlias()
     {
-        var newAliasString = string.IsNullOrWhiteSpace(AliasText) ?
-            string.Empty :
-            AliasText + (IsDirectAlias ? string.Empty : " ");
+        if (string.IsNullOrWhiteSpace(AliasText))
+        {
+            _item.UpdateAlias(null);
+        }
+        else
+        {
+            var newAlias = new CommandAlias(AliasText, _item.Id, IsDirectAlias);
+            _item.UpdateAlias(newAlias);
+        }
 
-        _item.UpdateAlias(newAliasString);
         Save();
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml
@@ -85,7 +85,7 @@
                                             Header="Alias"
                                             HeaderIcon="{ui:FontIcon Glyph=&#xE8AC;}">
                                             <StackPanel Orientation="Vertical">
-                                                <TextBox Text="{x:Bind AliasText, Mode=TwoWay}" KeyUp="AliasTextBox_KeyUp"/>
+                                                <TextBox Text="{x:Bind AliasText, Mode=TwoWay}"/>
                                                 <ToggleSwitch 
                                                     IsOn="{x:Bind IsDirectAlias, Mode=TwoWay}" 
                                                     IsEnabled="{x:Bind AliasText, Converter={StaticResource StringEmptyToBoolConverter}, Mode=OneWay}" 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml
@@ -29,6 +29,10 @@
                 x:Key="BoolToInvertedVisibilityConverter"
                 FalseValue="Visible"
                 TrueValue="Collapsed" />
+            <converters:EmptyStringToObjectConverter 
+                x:Key="StringEmptyToBoolConverter"
+                EmptyValue="False"
+                NotEmptyValue="True" />
         </ResourceDictionary>
     </Page.Resources>
 
@@ -75,6 +79,21 @@
                                             HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}">
                                             <cpcontrols:ShortcutControl HotkeySettings="{x:Bind Hotkey, Mode=TwoWay}" />
                                         </controls:SettingsCard>
+
+                                        <controls:SettingsCard
+                                            Description="Typing this alias will navigate to this command. Direct aliases navigate as soon as you type the alias. Indirect aliases navigate after typing a trailing space"
+                                            Header="Alias"
+                                            HeaderIcon="{ui:FontIcon Glyph=&#xE8AC;}">
+                                            <StackPanel Orientation="Vertical">
+                                                <TextBox Text="{x:Bind AliasText, Mode=TwoWay}"/>
+                                                <ToggleSwitch 
+                                                    IsOn="{x:Bind IsDirectAlias, Mode=TwoWay}" 
+                                                    IsEnabled="{x:Bind AliasText, Converter={StaticResource StringEmptyToBoolConverter}, Mode=OneWay}" 
+                                                    OffContent="Indirect" 
+                                                    OnContent="Direct"/>
+                                            </StackPanel>
+                                        </controls:SettingsCard>
+                                        
                                     </controls:SettingsExpander.Items>
                                 </controls:SettingsExpander>
                             </DataTemplate>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml
@@ -29,7 +29,7 @@
                 x:Key="BoolToInvertedVisibilityConverter"
                 FalseValue="Visible"
                 TrueValue="Collapsed" />
-            <converters:EmptyStringToObjectConverter 
+            <converters:EmptyStringToObjectConverter
                 x:Key="StringEmptyToBoolConverter"
                 EmptyValue="False"
                 NotEmptyValue="True" />
@@ -85,15 +85,15 @@
                                             Header="Alias"
                                             HeaderIcon="{ui:FontIcon Glyph=&#xE8AC;}">
                                             <StackPanel Orientation="Vertical">
-                                                <TextBox Text="{x:Bind AliasText, Mode=TwoWay}"/>
-                                                <ToggleSwitch 
-                                                    IsOn="{x:Bind IsDirectAlias, Mode=TwoWay}" 
-                                                    IsEnabled="{x:Bind AliasText, Converter={StaticResource StringEmptyToBoolConverter}, Mode=OneWay}" 
-                                                    OffContent="Indirect" 
-                                                    OnContent="Direct"/>
+                                                <TextBox Text="{x:Bind AliasText, Mode=TwoWay}" />
+                                                <ToggleSwitch
+                                                    IsEnabled="{x:Bind AliasText, Converter={StaticResource StringEmptyToBoolConverter}, Mode=OneWay}"
+                                                    IsOn="{x:Bind IsDirectAlias, Mode=TwoWay}"
+                                                    OffContent="Indirect"
+                                                    OnContent="Direct" />
                                             </StackPanel>
                                         </controls:SettingsCard>
-                                        
+
                                     </controls:SettingsExpander.Items>
                                 </controls:SettingsExpander>
                             </DataTemplate>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml
@@ -85,7 +85,7 @@
                                             Header="Alias"
                                             HeaderIcon="{ui:FontIcon Glyph=&#xE8AC;}">
                                             <StackPanel Orientation="Vertical">
-                                                <TextBox Text="{x:Bind AliasText, Mode=TwoWay}"/>
+                                                <TextBox Text="{x:Bind AliasText, Mode=TwoWay}" KeyUp="AliasTextBox_KeyUp"/>
                                                 <ToggleSwitch 
                                                     IsOn="{x:Bind IsDirectAlias, Mode=TwoWay}" 
                                                     IsEnabled="{x:Bind AliasText, Converter={StaticResource StringEmptyToBoolConverter}, Mode=OneWay}" 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml.cs
@@ -5,7 +5,6 @@
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using Windows.System;
 
 namespace Microsoft.CmdPal.UI.Pages;
 
@@ -22,20 +21,13 @@ public sealed partial class ExtensionPage : Page
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        ViewModel = e.Parameter is ProviderSettingsViewModel vm
-            ? vm
-            : throw new ArgumentException($"{nameof(ExtensionPage)} navigation args should be passed a {nameof(ProviderSettingsViewModel)}");
-    }
-
-    private void AliasTextBox_KeyUp(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
-    {
-        if (e.Key == VirtualKey.Enter)
+        if (e.Parameter is ProviderSettingsViewModel vm)
         {
-            if (sender is TextBox textBox)
-            {
-                // textBox.Focus(Microsoft.UI.Xaml.FocusState.Keyboard);
-                textBox.Text = textBox.Text;
-            }
+            ViewModel = vm;
+        }
+        else
+        {
+            throw new ArgumentException($"{nameof(ExtensionPage)} navigation args should be passed a {nameof(ProviderSettingsViewModel)}");
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/ExtensionPage.xaml.cs
@@ -5,6 +5,7 @@
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
+using Windows.System;
 
 namespace Microsoft.CmdPal.UI.Pages;
 
@@ -21,13 +22,20 @@ public sealed partial class ExtensionPage : Page
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
-        if (e.Parameter is ProviderSettingsViewModel vm)
+        ViewModel = e.Parameter is ProviderSettingsViewModel vm
+            ? vm
+            : throw new ArgumentException($"{nameof(ExtensionPage)} navigation args should be passed a {nameof(ProviderSettingsViewModel)}");
+    }
+
+    private void AliasTextBox_KeyUp(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.Enter)
         {
-            ViewModel = vm;
-        }
-        else
-        {
-            throw new ArgumentException($"{nameof(ExtensionPage)} navigation args should be passed a {nameof(ProviderSettingsViewModel)}");
+            if (sender is TextBox textBox)
+            {
+                // textBox.Focus(Microsoft.UI.Xaml.FocusState.Keyboard);
+                textBox.Text = textBox.Text;
+            }
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -99,7 +99,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
             return;
         }
 
-        if (!RootFrame.CanGoBack)
+        if (!ViewModel.CurrentPage.IsNested)
         {
             // on the main page here
             ViewModel.PerformTopLevelCommand(message);


### PR DESCRIPTION
This is a very rough UI element for setting aliases in the UI.


* the command weighting from #454 was bad. It would always grant a recent command weight. Probably shouldn't do that
* The tags could soft-crash when opening the SUI? I think that was from the ObservableCollection being created on a COM thread, then "updated" on the main thread. 
  * this may be #426 but I'm not sure
  
Closes #92 (but it isn't pretty)