### PR TITLE
Add to the SUI a setting to control where the window is summoned

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/ShowWindowMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/ShowWindowMessage.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.ViewModels.Messages;
+
+public record ShowWindowMessage(IntPtr Hwnd)
+{
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -40,6 +40,8 @@ public partial class SettingsModel : ObservableObject
 
     public List<TopLevelHotkey> CommandHotkeys { get; set; } = [];
 
+    public MonitorBehavior SummonOn { get; set; } = MonitorBehavior.ToMouse;
+
     // END SETTINGS
     ///////////////////////////////////////////////////////////////////////////
 
@@ -150,4 +152,11 @@ public partial class SettingsModel : ObservableObject
         PropertyNameCaseInsensitive = true,
         IncludeFields = true,
     };
+}
+
+public enum MonitorBehavior
+{
+    ToMouse = 0,
+    ToCurrent = 1,
+    InPlace = 2,
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -151,12 +151,15 @@ public partial class SettingsModel : ObservableObject
     {
         PropertyNameCaseInsensitive = true,
         IncludeFields = true,
+        Converters = { new JsonStringEnumConverter() },
+        AllowTrailingCommas = true,
     };
 }
 
 public enum MonitorBehavior
 {
     ToMouse = 0,
-    ToCurrent = 1,
-    InPlace = 2,
+    ToPrimary = 1,
+    ToFocusedWindow = 2,
+    InPlace = 3,
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -74,6 +74,16 @@ public partial class SettingsViewModel : PageViewModel
         }
     }
 
+    public int MonitorPositionIndex
+    {
+        get => (int)_settings.SummonOn;
+        set
+        {
+            _settings.SummonOn = (MonitorBehavior)value;
+            Save();
+        }
+    }
+
     public ObservableCollection<ProviderSettingsViewModel> CommandProviders { get; } = [];
 
     public SettingsViewModel(SettingsModel settings, IServiceProvider serviceProvider, TaskScheduler scheduler)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml
@@ -16,6 +16,9 @@
                 <ResourceDictionary Source="Controls/KeyVisual/KeyVisual.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!--  Other app resources here  -->
+
+            <x:Double x:Key="SettingActionControlMinWidth">240</x:Double>
+
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ namespace Microsoft.CmdPal.UI;
 
 public sealed partial class MainWindow : Window,
     IRecipient<DismissMessage>,
+    IRecipient<ShowWindowMessage>,
     IRecipient<QuitMessage>
 {
     private readonly HWND _hwnd;
@@ -64,11 +65,13 @@ public sealed partial class MainWindow : Window,
         // notification area icon back
         WM_TASKBAR_RESTART = PInvoke.RegisterWindowMessage("TaskbarCreated");
 
+        AppWindow.Resize(new SizeInt32 { Width = 1000, Height = 620 });
         PositionCentered();
         SetAcrylic();
 
         WeakReferenceMessenger.Default.Register<DismissMessage>(this);
         WeakReferenceMessenger.Default.Register<QuitMessage>(this);
+        WeakReferenceMessenger.Default.Register<ShowWindowMessage>(this);
 
         // Hide our titlebar.
         // We need to both ExtendsContentIntoTitleBar, then set the height to Collapsed
@@ -107,13 +110,20 @@ public sealed partial class MainWindow : Window,
 
     private void PositionCentered()
     {
-        AppWindow.Resize(new SizeInt32 { Width = 1000, Height = 620 });
         var displayArea = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Nearest);
+        PositionCentered(displayArea);
+    }
+
+    private void PositionCentered(DisplayArea displayArea)
+    {
         if (displayArea is not null)
         {
             var centeredPosition = AppWindow.Position;
             centeredPosition.X = (displayArea.WorkArea.Width - AppWindow.Size.Width) / 2;
             centeredPosition.Y = (displayArea.WorkArea.Height - AppWindow.Size.Height) / 2;
+
+            centeredPosition.X += displayArea.WorkArea.X;
+            centeredPosition.Y += displayArea.WorkArea.Y;
             AppWindow.Move(centeredPosition);
         }
     }
@@ -176,6 +186,91 @@ public sealed partial class MainWindow : Window,
                 TintOpacity = 0.5f,
                 FallbackColor = Color.FromArgb(255, 28, 28, 28),
             };
+    }
+
+    private void ShowHwnd(IntPtr hwndValue, MonitorBehavior target)
+    {
+        var hwnd = new HWND(hwndValue);
+
+        // Remember, IsIconic == "minimized", which is entirely different state
+        // from "show/hide"
+        // If we're currently minimized, restore us first, before we reveal
+        // our window. Otherwise we'd just be showing a minimized window -
+        // which would remain not visible to the user.
+        if (PInvoke.IsIconic(hwnd))
+        {
+            PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_RESTORE);
+        }
+
+        var display = GetScreen(hwnd, target);
+
+        // AppWindow.Move(new(display.WorkArea.X, display.WorkArea.Y));
+        PositionCentered(display);
+
+        // App.Current.AppWindow.AppWindow.
+        // PInvoke.SetWindowPos(hwnd,
+        //             0,
+        //             newOrigin.x,
+        //             newOrigin.y,
+        //             currentWindowRect.width(),
+        //             currentWindowRect.height(),
+        //             SWP_NOZORDER | SWP_NOSIZE | SWP_NOACTIVATE);
+        PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOW);
+        PInvoke.SetForegroundWindow(hwnd);
+        PInvoke.SetActiveWindow(hwnd);
+    }
+
+    private DisplayArea GetScreen(HWND currentHwnd, MonitorBehavior target)
+    {
+        // Leaving a note here, in case we ever need it:
+        // https://github.com/microsoft/microsoft-ui-xaml/issues/6454
+        // If we need to ever FindAll, we'll need to iterate manually
+        var displayAreas = Microsoft.UI.Windowing.DisplayArea.FindAll();
+        switch (target)
+        {
+            case MonitorBehavior.InPlace:
+                if (PInvoke.GetWindowRect(currentHwnd, out var bounds))
+                {
+                    RectInt32 converted = new(bounds.X, bounds.Y, bounds.Width, bounds.Height);
+                    return DisplayArea.GetFromRect(converted, DisplayAreaFallback.Nearest);
+                }
+
+                break;
+
+            case MonitorBehavior.ToFocusedWindow:
+                var foregroundWindowHandle = PInvoke.GetForegroundWindow();
+                if (foregroundWindowHandle != IntPtr.Zero)
+                {
+                    if (PInvoke.GetWindowRect(foregroundWindowHandle, out var fgBounds))
+                    {
+                        RectInt32 converted = new(fgBounds.X, fgBounds.Y, fgBounds.Width, fgBounds.Height);
+                        return DisplayArea.GetFromRect(converted, DisplayAreaFallback.Nearest);
+                    }
+                }
+
+                break;
+
+            case MonitorBehavior.ToPrimary:
+                return DisplayArea.Primary;
+
+            case MonitorBehavior.ToMouse:
+            default:
+                if (PInvoke.GetCursorPos(out var cursorPos))
+                {
+                    return DisplayArea.GetFromPoint(new PointInt32(cursorPos.X, cursorPos.Y), DisplayAreaFallback.Nearest);
+                }
+
+                break;
+        }
+
+        return DisplayArea.Primary;
+    }
+
+    public void Receive(ShowWindowMessage message)
+    {
+        var settings = App.Current.Services.GetService<SettingsModel>()!;
+
+        ShowHwnd(message.Hwnd, settings.SummonOn);
     }
 
     public void Receive(QuitMessage message) =>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -203,18 +203,8 @@ public sealed partial class MainWindow : Window,
         }
 
         var display = GetScreen(hwnd, target);
-
-        // AppWindow.Move(new(display.WorkArea.X, display.WorkArea.Y));
         PositionCentered(display);
 
-        // App.Current.AppWindow.AppWindow.
-        // PInvoke.SetWindowPos(hwnd,
-        //             0,
-        //             newOrigin.x,
-        //             newOrigin.y,
-        //             currentWindowRect.width(),
-        //             currentWindowRect.height(),
-        //             SWP_NOZORDER | SWP_NOSIZE | SWP_NOACTIVATE);
         PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOW);
         PInvoke.SetForegroundWindow(hwnd);
         PInvoke.SetActiveWindow(hwnd);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
@@ -2,7 +2,11 @@ GetPhysicallyInstalledSystemMemory
 GlobalMemoryStatusEx
 GetSystemInfo
 CoCreateInstance
+GetForegroundWindow
 SetForegroundWindow
+GetWindowRect
+GetCursorPos
+SetWindowPos
 IsIconic
 RegisterHotKey
 UnregisterHotKey

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/GeneralPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/GeneralPage.xaml
@@ -59,6 +59,7 @@
                                     <ComboBoxItem x:Uid="Run_Radio_Position_Cursor" />
                                     <ComboBoxItem x:Uid="Run_Radio_Position_Primary_Monitor" />
                                     <ComboBoxItem x:Uid="Run_Radio_Position_Focus" />
+                                    <ComboBoxItem x:Uid="Run_Radio_Position_In_Place" />
                                 </ComboBox>
                             </controls:SettingsCard>
                             

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/GeneralPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/GeneralPage.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <Page
     x:Class="Microsoft.CmdPal.UI.Pages.GeneralPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -50,19 +50,15 @@
                             <controls:SettingsCard Description="When enabled, the previous search text will be selected when the app is opened" Header="Highlight search on activate">
                                 <ToggleSwitch IsOn="{x:Bind viewModel.HighlightSearchOnActivate, Mode=TwoWay}" />
                             </controls:SettingsCard>
-                            <controls:SettingsCard 
-                                x:Uid="Run_PositionHeader" 
-                                HeaderIcon="{ui:FontIcon Glyph=&#xe78b;}">
-                                <ComboBox 
-                                    MinWidth="{StaticResource SettingActionControlMinWidth}" 
-                                    SelectedIndex="{x:Bind viewModel.MonitorPositionIndex, Mode=TwoWay}">
+                            <controls:SettingsCard x:Uid="Run_PositionHeader" HeaderIcon="{ui:FontIcon Glyph=&#xe78b;}">
+                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind viewModel.MonitorPositionIndex, Mode=TwoWay}">
                                     <ComboBoxItem x:Uid="Run_Radio_Position_Cursor" />
                                     <ComboBoxItem x:Uid="Run_Radio_Position_Primary_Monitor" />
                                     <ComboBoxItem x:Uid="Run_Radio_Position_Focus" />
                                     <ComboBoxItem x:Uid="Run_Radio_Position_In_Place" />
                                 </ComboBox>
                             </controls:SettingsCard>
-                            
+
                         </controls:SettingsExpander.Items>
                     </controls:SettingsExpander>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/GeneralPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/Settings/GeneralPage.xaml
@@ -50,6 +50,18 @@
                             <controls:SettingsCard Description="When enabled, the previous search text will be selected when the app is opened" Header="Highlight search on activate">
                                 <ToggleSwitch IsOn="{x:Bind viewModel.HighlightSearchOnActivate, Mode=TwoWay}" />
                             </controls:SettingsCard>
+                            <controls:SettingsCard 
+                                x:Uid="Run_PositionHeader" 
+                                HeaderIcon="{ui:FontIcon Glyph=&#xe78b;}">
+                                <ComboBox 
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}" 
+                                    SelectedIndex="{x:Bind viewModel.MonitorPositionIndex, Mode=TwoWay}">
+                                    <ComboBoxItem x:Uid="Run_Radio_Position_Cursor" />
+                                    <ComboBoxItem x:Uid="Run_Radio_Position_Primary_Monitor" />
+                                    <ComboBoxItem x:Uid="Run_Radio_Position_Focus" />
+                                </ComboBox>
+                            </controls:SettingsCard>
+                            
                         </controls:SettingsExpander.Items>
                     </controls:SettingsExpander>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -336,7 +336,6 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         if (isRoot)
         {
             // If this is the hotkey for the root level, then always show us
-            // ShowHwnd(message.Hwnd, settings.SummonOn);
             WeakReferenceMessenger.Default.Send<ShowWindowMessage>(new(message.Hwnd));
 
             // Depending on the settings, either
@@ -373,7 +372,6 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
                         // of some kind. Let's pop the stack, show the window, and navigate to it.
                         GoHome(false);
 
-                        // ShowHwnd(message.Hwnd, settings.SummonOn);
                         WeakReferenceMessenger.Default.Send<ShowWindowMessage>(new(message.Hwnd));
                     }
 
@@ -394,24 +392,6 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
     }
 
-    // private void ShowHwnd(IntPtr hwndValue, MonitorBehavior target)
-    // {
-    //    var hwnd = new HWND(hwndValue);
-
-    // // Remember, IsIconic == "minimized", which is entirely different state
-    //    // from "show/hide"
-    //    // If we're currently minimized, restore us first, before we reveal
-    //    // our window. Otherwise we'd just be showing a minimized window -
-    //    // which would remain not visible to the user.
-    //    if (PInvoke.IsIconic(hwnd))
-    //    {
-    //        PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_RESTORE);
-    //    }
-
-    // PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOW);
-    //    PInvoke.SetForegroundWindow(hwnd);
-    //    PInvoke.SetActiveWindow(hwnd);
-    // }
     private void GoBack(bool withAnimation = true, bool focusSearch = true)
     {
         HideDetails();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -12,9 +12,6 @@ using Microsoft.CommandPalette.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Media.Animation;
-using Windows.Win32;
-using Windows.Win32.Foundation;
-using Windows.Win32.UI.WindowsAndMessaging;
 using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
 
 namespace Microsoft.CmdPal.UI.Pages;
@@ -328,90 +325,93 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
     public void Receive(HotkeySummonMessage message)
     {
-        var settings = App.Current.Services.GetService<SettingsModel>()!;
-
-        _ = DispatcherQueue.TryEnqueue(() =>
-        {
-            var commandId = message.CommandId;
-            var isRoot = string.IsNullOrEmpty(commandId);
-            if (isRoot)
-            {
-                // If this is the hotkey for the root level, then always show us
-                ShowHwnd(message.Hwnd);
-
-                // Depending on the settings, either
-                // * Go home, or
-                // * Select the search text (if we should remain open on this page)
-                if (settings.HotkeyGoesHome)
-                {
-                    GoHome(false);
-                }
-                else if (settings.HighlightSearchOnActivate)
-                {
-                    SearchBox.SelectSearch();
-                }
-            }
-            else
-            {
-                try
-                {
-                    // For a hotkey bound to a command, first lookup the
-                    // command from our list of toplevel commands.
-                    var tlcManager = App.Current.Services.GetService<TopLevelCommandManager>()!;
-                    var topLevelCommand = tlcManager.LookupCommand(commandId);
-                    if (topLevelCommand != null)
-                    {
-                        var command = topLevelCommand.Command;
-                        var isPage = command is TopLevelCommandWrapper wrapper && wrapper.Command is not IInvokableCommand;
-
-                        // If the bound command is an invokable command, then
-                        // we don't want to open the window at all - we want to
-                        // just do it.
-                        if (isPage)
-                        {
-                            // If we're here, then the bound command was a page
-                            // of some kind. Let's pop the stack, show the window, and navigate to it.
-                            GoHome(false);
-                            ShowHwnd(message.Hwnd);
-                        }
-
-                        var msg = new PerformCommandMessage(new(topLevelCommand.Command)) { WithAnimation = false };
-                        WeakReferenceMessenger.Default.Send<PerformCommandMessage>(msg);
-
-                        // we can't necessarily SelectSearch() here, because when the page is loaded,
-                        // we'll fetch the SearchText from the page itself, and that'll stomp the
-                        // selection we start now.
-                        // That's probably okay though.
-                    }
-                }
-                catch
-                {
-                }
-            }
-
-            WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
-        });
+        _ = DispatcherQueue.TryEnqueue(() => SummonOnUiThread(message));
     }
 
-    private void ShowHwnd(IntPtr hwndValue)
+    private void SummonOnUiThread(HotkeySummonMessage message)
     {
-        var hwnd = new HWND(hwndValue);
-
-        // Remember, IsIconic == "minimized", which is entirely different state
-        // from "show/hide"
-        // If we're currently minimized, restore us first, before we reveal
-        // our window. Otherwise we'd just be showing a minimized window -
-        // which would remain not visible to the user.
-        if (PInvoke.IsIconic(hwnd))
+        var settings = App.Current.Services.GetService<SettingsModel>()!;
+        var commandId = message.CommandId;
+        var isRoot = string.IsNullOrEmpty(commandId);
+        if (isRoot)
         {
-            PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_RESTORE);
+            // If this is the hotkey for the root level, then always show us
+            // ShowHwnd(message.Hwnd, settings.SummonOn);
+            WeakReferenceMessenger.Default.Send<ShowWindowMessage>(new(message.Hwnd));
+
+            // Depending on the settings, either
+            // * Go home, or
+            // * Select the search text (if we should remain open on this page)
+            if (settings.HotkeyGoesHome)
+            {
+                GoHome(false);
+            }
+            else if (settings.HighlightSearchOnActivate)
+            {
+                SearchBox.SelectSearch();
+            }
+        }
+        else
+        {
+            try
+            {
+                // For a hotkey bound to a command, first lookup the
+                // command from our list of toplevel commands.
+                var tlcManager = App.Current.Services.GetService<TopLevelCommandManager>()!;
+                var topLevelCommand = tlcManager.LookupCommand(commandId);
+                if (topLevelCommand != null)
+                {
+                    var command = topLevelCommand.Command;
+                    var isPage = command is TopLevelCommandWrapper wrapper && wrapper.Command is not IInvokableCommand;
+
+                    // If the bound command is an invokable command, then
+                    // we don't want to open the window at all - we want to
+                    // just do it.
+                    if (isPage)
+                    {
+                        // If we're here, then the bound command was a page
+                        // of some kind. Let's pop the stack, show the window, and navigate to it.
+                        GoHome(false);
+
+                        // ShowHwnd(message.Hwnd, settings.SummonOn);
+                        WeakReferenceMessenger.Default.Send<ShowWindowMessage>(new(message.Hwnd));
+                    }
+
+                    var msg = new PerformCommandMessage(new(topLevelCommand.Command)) { WithAnimation = false };
+                    WeakReferenceMessenger.Default.Send<PerformCommandMessage>(msg);
+
+                    // we can't necessarily SelectSearch() here, because when the page is loaded,
+                    // we'll fetch the SearchText from the page itself, and that'll stomp the
+                    // selection we start now.
+                    // That's probably okay though.
+                }
+            }
+            catch
+            {
+            }
         }
 
-        PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOW);
-        PInvoke.SetForegroundWindow(hwnd);
-        PInvoke.SetActiveWindow(hwnd);
+        WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
     }
 
+    // private void ShowHwnd(IntPtr hwndValue, MonitorBehavior target)
+    // {
+    //    var hwnd = new HWND(hwndValue);
+
+    // // Remember, IsIconic == "minimized", which is entirely different state
+    //    // from "show/hide"
+    //    // If we're currently minimized, restore us first, before we reveal
+    //    // our window. Otherwise we'd just be showing a minimized window -
+    //    // which would remain not visible to the user.
+    //    if (PInvoke.IsIconic(hwnd))
+    //    {
+    //        PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_RESTORE);
+    //    }
+
+    // PInvoke.ShowWindow(hwnd, SHOW_WINDOW_CMD.SW_SHOW);
+    //    PInvoke.SetForegroundWindow(hwnd);
+    //    PInvoke.SetActiveWindow(hwnd);
+    // }
     private void GoBack(bool withAnimation = true, bool focusSearch = true)
     {
         HideDetails();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/SettingsWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/SettingsWindow.xaml
@@ -37,6 +37,7 @@
             IsBackButtonVisible="Collapsed"
             IsSettingsVisible="False"
             ItemInvoked="NavView_ItemInvoked"
+            OpenPaneLength="200"
             Loaded="NavView_Loaded">
             <NavigationView.Resources>
                 <SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/SettingsWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/SettingsWindow.xaml
@@ -37,8 +37,8 @@
             IsBackButtonVisible="Collapsed"
             IsSettingsVisible="False"
             ItemInvoked="NavView_ItemInvoked"
-            OpenPaneLength="200"
-            Loaded="NavView_Loaded">
+            Loaded="NavView_Loaded"
+            OpenPaneLength="200">
             <NavigationView.Resources>
                 <SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />
                 <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="Transparent" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -188,4 +188,7 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   <data name="Run_Radio_Position_Primary_Monitor.Content" xml:space="preserve">
     <value>Primary monitor</value>
   </data>
+  <data name="Run_Radio_Position_In_Place.Content" xml:space="preserve">
+    <value>Don't move</value>
+  </data>
 </root>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -171,4 +171,21 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Commands</value>
     <comment>A section header for information about the app</comment>
   </data>
+  <data name="Run_PositionHeader.Header" xml:space="preserve">
+    <value>Preferred monitor position</value>
+    <comment>as in Show Command Palette on primary monitor</comment>
+  </data>
+  <data name="Run_PositionHeader.Description" xml:space="preserve">
+    <value>If multiple monitors are in use, Command Palette can be launched on the desired monitor</value>
+    <comment>as in Show Command Palette on primary monitor</comment>
+  </data>
+  <data name="Run_Radio_Position_Cursor.Content" xml:space="preserve">
+    <value>Monitor with mouse cursor</value>
+  </data>
+  <data name="Run_Radio_Position_Focus.Content" xml:space="preserve">
+    <value>Monitor with focused window</value>
+  </data>
+  <data name="Run_Radio_Position_Primary_Monitor.Content" xml:space="preserve">
+    <value>Primary monitor</value>
+  </data>
 </root>


### PR DESCRIPTION
Closes #446

Setting is pretty straightforward. Same as PT Run, with an added "leave it where it is", from the Terminal codebase. 

The `DisplayArea` code is net-new (PT used WPF for that, and Terminal used C++), but it's pretty same-y to everything else. 

Drive-by fixes "holy whitespace batman", by making the SUI less wide.