### PR TITLE
Add support for svg icons

### DIFF
--- a/src/modules/cmdpal/Microsoft.Terminal.UI/IconPathConverter.cpp
+++ b/src/modules/cmdpal/Microsoft.Terminal.UI/IconPathConverter.cpp
@@ -61,6 +61,31 @@ namespace winrt::Microsoft::Terminal::UI::implementation
     };*/
 #pragma endregion
 
+#pragma region PathIconSource
+    template<typename TIconSource>
+    struct PathIconSource
+    {
+    };
+
+    template<>
+    struct PathIconSource<winrt::Microsoft::UI::Xaml::Controls::IconSource>
+    {
+        using type = winrt::Microsoft::UI::Xaml::Controls::PathIconSource;
+    };
+#pragma endregion
+#pragma region ImageIconSource
+    template<typename TIconSource>
+    struct ImageIconSource
+    {
+    };
+
+    template<>
+    struct ImageIconSource<winrt::Microsoft::UI::Xaml::Controls::IconSource>
+    {
+        using type = winrt::Microsoft::UI::Xaml::Controls::ImageIconSource;
+    };
+#pragma endregion
+
     // Method Description:
     // - Creates an IconSource for the given path. The icon returned is a colored
     //   icon. If we couldn't create the icon for any reason, we return an empty
@@ -81,6 +106,16 @@ namespace winrt::Microsoft::Terminal::UI::implementation
             try
             {
                 winrt::Windows::Foundation::Uri iconUri{ path };
+
+                if (til::equals_insensitive_ascii(iconUri.Extension(), L".svg"))
+                {
+                    typename ImageIconSource<TIconSource>::type iconSource;
+                    winrt::Microsoft::UI::Xaml::Media::Imaging::SvgImageSource source{ iconUri };	
+                    iconSource.ImageSource(source);
+                    return iconSource;
+                }
+                else
+                {
                 typename BitmapIconSource<TIconSource>::type iconSource;
                 // Make sure to set this to false, so we keep the RGB data of the
                 // image. Otherwise, the icon will be white for all the
@@ -88,6 +123,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
                 iconSource.ShowAsMonochrome(monochrome);
                 iconSource.UriSource(iconUri);
                 return iconSource;
+            }
             }
             CATCH_LOG();
         }

--- a/src/modules/cmdpal/Microsoft.Terminal.UI/IconPathConverter.cpp
+++ b/src/modules/cmdpal/Microsoft.Terminal.UI/IconPathConverter.cpp
@@ -116,14 +116,14 @@ namespace winrt::Microsoft::Terminal::UI::implementation
                 }
                 else
                 {
-                typename BitmapIconSource<TIconSource>::type iconSource;
-                // Make sure to set this to false, so we keep the RGB data of the
-                // image. Otherwise, the icon will be white for all the
-                // non-transparent pixels in the image.
-                iconSource.ShowAsMonochrome(monochrome);
-                iconSource.UriSource(iconUri);
-                return iconSource;
-            }
+                    typename BitmapIconSource<TIconSource>::type iconSource;
+                    // Make sure to set this to false, so we keep the RGB data of the
+                    // image. Otherwise, the icon will be white for all the
+                    // non-transparent pixels in the image.
+                    iconSource.ShowAsMonochrome(monochrome);
+                    iconSource.UriSource(iconUri);
+                    return iconSource;
+                }
             }
             CATCH_LOG();
         }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/IconInfo.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/IconInfo.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Windows.Storage.Streams;
+
 namespace Microsoft.CommandPalette.Extensions.Toolkit;
 
 public partial class IconInfo : IIconInfo
@@ -28,5 +30,11 @@ public partial class IconInfo : IIconInfo
     internal IconInfo()
         : this(string.Empty)
     {
+    }
+
+    public static IconInfo FromStream(IRandomAccessStream stream)
+    {
+        var data = new IconData(RandomAccessStreamReference.CreateFromStream(stream));
+        return new IconInfo(data, data);
     }
 }

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
@@ -30,7 +30,7 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
 
     private IEnumerable<CatalogPackage>? _results;
 
-    public static IconInfo WinGetIcon { get; } = IconHelpers.FromRelativePath("Assets\\WinGet.png");
+    public static IconInfo WinGetIcon { get; } = IconHelpers.FromRelativePath("Assets\\WinGet.svg");
 
     public static IconInfo ExtensionsIcon { get; } = new("\uEA86"); // Puzzle
 


### PR DESCRIPTION
Yep, it was this easy to add an SVG as an ImageSource on WinUI 3

Pretty sure it's impossible in WinUI 2 though

This is related to #182, but I think we should also like allow for `<path>` icons too