### PR TITLE
[GPO]Add a policy for controlling CmdPal enabled state

### DIFF
--- a/src/gpo/assets/PowerToys.admx
+++ b/src/gpo/assets/PowerToys.admx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation.
      Licensed under the MIT License. -->
-<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.16" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.17" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <policyNamespaces>
     <target prefix="powertoys" namespace="Microsoft.Policies.PowerToys" />
   </policyNamespaces>
-  <resources minRequiredRevision="1.16"/><!-- Last changed with PowerToys v0.89.0 -->
+  <resources minRequiredRevision="1.17"/><!-- Last changed with PowerToys v0.90.0 -->
   <supportedOn>
     <definitions>
       <definition name="SUPPORTED_POWERTOYS_0_64_0" displayName="$(string.SUPPORTED_POWERTOYS_0_64_0)"/>
@@ -25,6 +25,7 @@
       <definition name="SUPPORTED_POWERTOYS_0_86_0" displayName="$(string.SUPPORTED_POWERTOYS_0_86_0)"/>
       <definition name="SUPPORTED_POWERTOYS_0_88_0" displayName="$(string.SUPPORTED_POWERTOYS_0_88_0)"/>
       <definition name="SUPPORTED_POWERTOYS_0_89_0" displayName="$(string.SUPPORTED_POWERTOYS_0_89_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_90_0" displayName="$(string.SUPPORTED_POWERTOYS_0_90_0)"/>
       <definition name="SUPPORTED_POWERTOYS_0_64_0_TO_0_87_1" displayName="$(string.SUPPORTED_POWERTOYS_0_64_0_TO_0_87_1)"/>
     </definitions>
   </supportedOn>
@@ -108,7 +109,7 @@
     </policy>
     <policy name="ConfigureEnabledUtilityCmdPal" class="Both" displayName="$(string.ConfigureEnabledUtilityCmdPal)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCmdPal">
       <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_8xxxxxx_0" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_90_0" />
       <enabledValue>
         <decimal value="1" />
       </enabledValue>

--- a/src/gpo/assets/en-US/PowerToys.adml
+++ b/src/gpo/assets/en-US/PowerToys.adml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation.
      Licensed under the MIT License. -->
-<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.16" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.17" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <displayName>PowerToys</displayName>
   <description>PowerToys</description>
   <resources>
@@ -32,6 +32,7 @@
       <string id="SUPPORTED_POWERTOYS_0_86_0">PowerToys version 0.86.0 or later</string>
       <string id="SUPPORTED_POWERTOYS_0_88_0">PowerToys version 0.88.0 or later</string>
       <string id="SUPPORTED_POWERTOYS_0_89_0">PowerToys version 0.89.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_90_0">PowerToys version 0.90.0 or later</string>
       <string id="SUPPORTED_POWERTOYS_0_64_0_TO_0_87_1">From PowerToys version 0.64.0 until PowerToys version 0.87.1</string>
 
       <string id="ConfigureAllUtilityGlobalEnabledStateDescription">This policy configures the enabled state for all PowerToys utilities.
@@ -234,6 +235,7 @@ If you don't configure this policy, the user takes control over the setting and 
       <string id="ConfigureEnabledUtilityAwake">Awake: Configure enabled state</string>
       <string id="ConfigureEnabledUtilityColorPicker">Color Picker: Configure enabled state</string>
       <string id="ConfigureEnabledUtilityCmdNotFound">Command Not Found: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityCmdPal">CmdPal: Configure enabled state</string>
       <string id="ConfigureEnabledUtilityCropAndLock">Crop And Lock: Configure enabled state</string>
       <string id="ConfigureEnabledUtilityEnvironmentVariables">Environment Variables: Configure enabled state</string>
       <string id="ConfigureEnabledUtilityFancyZones">FancyZones: Configure enabled state</string>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/GpoValueChecker.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/GpoValueChecker.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.Bookmarks;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.Win32;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+internal enum GpoRuleConfiguredValue
+{
+    WrongValue = -3,
+    Unavailable = -2,
+    NotConfigured = -1,
+    Disabled = 0,
+    Enabled = 1,
+}
+
+/*
+ * Contains methods extracted from PowerToys gpo.h
+ * The idea is to keep CmdPal codebase take as little dependences on the PowerToys codebase as possible.
+ * Having this class to check GPO being contained in CmdPal means we don't need to depend on GPOWrapper.
+ */
+internal static class GpoValueChecker
+{
+    private const string PoliciesPath = @"SOFTWARE\Policies\PowerToys";
+    private static readonly RegistryKey PoliciesScopeMachine = Registry.LocalMachine;
+    private static readonly RegistryKey PoliciesScopeUser = Registry.CurrentUser;
+    private const string PolicyConfigureEnabledCmdPal = @"ConfigureEnabledUtilityCmdPal";
+    private const string PolicyConfigureEnabledGlobalAllUtilities = @"ConfigureGlobalUtilityEnabledState";
+
+    private static GpoRuleConfiguredValue GetConfiguredValue(string registryValueName)
+    {
+        // For GPO policies, machine scope should take precedence over user scope
+        var value = ReadRegistryValue(PoliciesScopeMachine, PoliciesPath, registryValueName);
+
+        if (!value.HasValue)
+        {
+            // If not found in machine scope, check user scope
+            value = ReadRegistryValue(PoliciesScopeUser, PoliciesPath, registryValueName);
+            if (!value.HasValue)
+            {
+                return GpoRuleConfiguredValue.NotConfigured;
+            }
+        }
+
+        return value switch
+        {
+            0 => GpoRuleConfiguredValue.Disabled,
+            1 => GpoRuleConfiguredValue.Enabled,
+            _ => GpoRuleConfiguredValue.WrongValue,
+        };
+    }
+
+    // Reads an integer registry value if it exists.
+    private static int? ReadRegistryValue(RegistryKey rootKey, string subKeyPath, string valueName)
+    {
+        using (RegistryKey? key = rootKey.OpenSubKey(subKeyPath, false))
+        {
+            if (key == null)
+            {
+                return null;
+            }
+
+            var value = key.GetValue(valueName);
+            if (value is int intValue)
+            {
+                return intValue;
+            }
+
+            return null;
+        }
+    }
+
+    private static GpoRuleConfiguredValue GetUtilityEnabledValue(string utilityName)
+    {
+        var individualValue = GetConfiguredValue(utilityName);
+
+        if (individualValue == GpoRuleConfiguredValue.Disabled || individualValue == GpoRuleConfiguredValue.Enabled)
+        {
+            return individualValue;
+        }
+        else
+        {
+            // If the individual utility value is not set, check the global all utilities policy value.
+            return GetConfiguredValue(PolicyConfigureEnabledGlobalAllUtilities);
+        }
+    }
+
+    internal static GpoRuleConfiguredValue GetConfiguredCmdPalEnabledValue()
+    {
+        return GetUtilityEnabledValue(PolicyConfigureEnabledCmdPal);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Program.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Program.cs
@@ -19,6 +19,12 @@ internal sealed class Program
     [STAThread]
     private static int Main(string[] args)
     {
+        if (Helpers.GpoValueChecker.GetConfiguredCmdPalEnabledValue() == Helpers.GpoRuleConfiguredValue.Disabled)
+        {
+            // There's a GPO rule configured disabling CmdPal. Exit as soon as possible.
+            return 0;
+        }
+
         WinRT.ComWrappersSupport.InitializeComWrappers();
         var isRedirect = DecideRedirection();
         if (!isRedirect)

--- a/tools/BugReportTool/BugReportTool/ReportGPOValues.cpp
+++ b/tools/BugReportTool/BugReportTool/ReportGPOValues.cpp
@@ -45,6 +45,7 @@ void ReportGPOValues(const std::filesystem::path &tmpDir)
     report << "getConfiguredAdvancedPasteEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredAdvancedPasteEnabledValue()) << std::endl;
     report << "getConfiguredAlwaysOnTopEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredAlwaysOnTopEnabledValue()) << std::endl;
     report << "getConfiguredAwakeEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredAwakeEnabledValue()) << std::endl;
+    report << "getConfiguredCmdPalEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredCmdPalEnabledValue()) << std::endl;
     report << "getConfiguredColorPickerEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredColorPickerEnabledValue()) << std::endl;
     report << "getConfiguredCropAndLockEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredCropAndLockEnabledValue()) << std::endl;
     report << "getConfiguredFancyZonesEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredFancyZonesEnabledValue()) << std::endl;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Some of the changes for GPO were already on the repo, so this PR just completes functionality.
- Completes the required .admx and .adml files for adding a policy for controlling the enabled state of CmdPal within PowerToys.
- Ports some of the GPO C++ code from the PowerToys source to C# inside CmdPal's codebase, to reduce dependencies on PowerToys.
- Check GPO during CmdPal startup in order to stop execution as soon as possible in CmdPal's lifecycle.

Note: Dashboard in Settings seems to be broken, but that doesn't seem to be caused by this specific PR.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Copy "src\gpo\assets\PowerToys.admx" to "C:\Windows\PolicyDefinitions".
- Copy "src\gpo\assets\en-US\PowerToys.adml" to "C:\Windows\PolicyDefinitions\en-US".
- Open gpedit.msc and verify the policy exists in both Computer Configurations and User Configuration.
![image](https://github.com/user-attachments/assets/45018a05-463e-4983-aa30-63f9a297f512)
- Exit PowerToys and set the policy to Disabled:
![image](https://github.com/user-attachments/assets/97269902-9054-43e4-be54-e54448e6f9ab)
- Start PowerToys and verify that CmdPal is disabled in Settings and that you can't enable it:
![image](https://github.com/user-attachments/assets/1557431a-446f-444f-a322-c241c1e4a3b7)
![image](https://github.com/user-attachments/assets/8e4df03f-dbfe-4c51-b2da-e592448c6bcc)
- Try to start CmdPal directly and verify it just exits without starting.
- Exit PowerToys and set the policy to Enabled.
- Start PowerToys and verify that CmdPal is enabled in Settings and that you can't disable it:
![image](https://github.com/user-attachments/assets/fbedb58c-40a9-47a8-9417-16d62e0a85b8)
- Remember to set the policies to "Not configured" after validating.