### PR TITLE
[File Search] Fix unresponsive UI after scrolling

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -33,6 +33,8 @@ public partial class ListViewModel : PageViewModel, IDisposable
     private readonly Lock _listLock = new();
 
     public event TypedEventHandler<ListViewModel, object>? ItemsUpdated;
+
+    public bool HasMoreItems => _model.Unsafe?.HasMoreItems ?? false;
 
     public bool ShowEmptyContent =>
         IsInitialized &&
@@ -373,12 +375,15 @@ public partial class ListViewModel : PageViewModel, IDisposable
         model.ItemsChanged += Model_ItemsChanged;
     }
 
-    public void LoadMoreIfNeeded()
+    public void LoadMore()
     {
-        if (_model.Unsafe?.HasMoreItems ?? false)
+        var model = this._model.Unsafe;
+        if (model == null)
         {
-            _model.Unsafe.LoadMore();
+            return;
         }
+
+        model.LoadMore();
     }
 
     protected override void FetchProperty(string propertyName)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -166,7 +166,11 @@ public sealed partial class ListPage : Page,
         // extension a bit of a heads-up before the user actually gets there.
         if (scrollView.VerticalOffset >= (scrollView.ScrollableHeight * .8))
         {
-            ViewModel?.LoadMoreIfNeeded();
+            var vm = ViewModel;
+            _ = Task.Run(() =>
+            {
+                vm?.LoadMoreIfNeeded();
+            });
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -27,6 +27,8 @@ public sealed partial class ListPage : Page,
         set => SetValue(ViewModelProperty, value);
     }
 
+    private bool _loadMoreInProgress;
+
     // Using a DependencyProperty as the backing store for ViewModel.  This enables animation, styling, binding, etc...
     public static readonly DependencyProperty ViewModelProperty =
         DependencyProperty.Register(nameof(ViewModel), typeof(ListViewModel), typeof(ListPage), new PropertyMetadata(null, OnViewModelChanged));
@@ -166,11 +168,7 @@ public sealed partial class ListPage : Page,
         // extension a bit of a heads-up before the user actually gets there.
         if (scrollView.VerticalOffset >= (scrollView.ScrollableHeight * .8))
         {
-            var vm = ViewModel;
-            _ = Task.Run(() =>
-            {
-                vm?.LoadMoreIfNeeded();
-            });
+            LoadMoreIfNeeded();
         }
     }
 
@@ -251,6 +249,8 @@ public sealed partial class ListPage : Page,
         {
             ItemsList.SelectedIndex = 0;
         }
+
+        _loadMoreInProgress = false;
     }
 
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -280,5 +280,19 @@ public sealed partial class ListPage : Page,
         }
 
         return null;
+    }
+
+    private void LoadMoreIfNeeded()
+    {
+        if (!_loadMoreInProgress && (ViewModel?.HasMoreItems ?? false))
+        {
+            _loadMoreInProgress = true;
+
+            var vm = ViewModel;
+            _ = Task.Run(() =>
+            {
+                vm?.LoadMore();
+            });
+        }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

UI could become unresponsive after searching and scrolling through files (to reproduce, I needed around 180-260 items in the list).

The fix forces triggering loading more on a non-UI thread and ensures non-simultaneous loading.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

