### PR TITLE
[OOBE]Fix crash when opening OOBE

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeShellPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeShellPage.xaml.cs
@@ -93,6 +93,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
                 ModuleName = "CmdNotFound",
                 IsNew = false,
             });
+            Modules.Insert((int)PowerToysModules.CmdPal, new OobePowerToysModule()
+            {
+                ModuleName = "CmdPal",
+                IsNew = true,
+            });
             Modules.Insert((int)PowerToysModules.ColorPicker, new OobePowerToysModule()
             {
                 ModuleName = "ColorPicker",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Oobe changes were missing the insert of a module, causing Settings to crash when we tried to open OOBE.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Run PowerToys Settings and click "Welcome to PowerToys" and verify it doesn't crash.