### PR TITLE
A pair of threading issues: MoreCommands and Tags

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -325,14 +325,17 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
                         ListHelpers.InPlaceUpdateList(MoreCommands, newContextMenu);
                     }
 
-                    MoreCommands.ForEach(contextItem =>
+                    newContextMenu.ForEach(contextItem =>
                     {
                         contextItem.InitializeProperties();
                     });
                 }
                 else
                 {
-                    MoreCommands.Clear();
+                    lock (MoreCommands)
+                    {
+                        MoreCommands.Clear();
+                    }
                 }
 
                 UpdateProperty(nameof(SecondaryCommand));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
@@ -17,11 +17,11 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
     public new ExtensionObject<IListItem> Model { get; } = new(model);
 
     [ObservableProperty]
-    public partial ObservableCollection<TagViewModel> Tags { get; set; } = [];
+    public partial ObservableCollection<TagViewModel>? Tags { get; set; } // = [];
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
-    public bool HasTags => Tags.Count > 0;
+    public bool HasTags => (Tags?.Count ?? 0) > 0;
 
     public string TextToSuggest { get; private set; } = string.Empty;
 
@@ -61,7 +61,6 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
             UpdateProperty(nameof(HasDetails));
         }
 
-        UpdateProperty(nameof(Tags));
         UpdateProperty(nameof(TextToSuggest));
         UpdateProperty(nameof(Section));
     }
@@ -122,11 +121,13 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
         Task.Factory.StartNew(
             () =>
             {
+                Tags ??= new();
                 lock (Tags)
                 {
                     ListHelpers.InPlaceUpdateList(Tags, newTags);
                 }
 
+                UpdateProperty(nameof(Tags));
                 UpdateProperty(nameof(HasTags));
             },
             CancellationToken.None,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
@@ -17,7 +17,7 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
     public new ExtensionObject<IListItem> Model { get; } = new(model);
 
     [ObservableProperty]
-    public partial ObservableCollection<TagViewModel>? Tags { get; set; } // = [];
+    public partial ObservableCollection<TagViewModel>? Tags { get; set; }
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
@@ -121,6 +121,8 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
         Task.Factory.StartNew(
             () =>
             {
+                // The Tags ObservableCollection _MUST_ be created on the UI
+                // thread. If it isn't, then binding to it's changes in the UI won't work
                 Tags ??= new();
                 lock (Tags)
                 {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
@@ -2,9 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -16,8 +14,7 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
 {
     public new ExtensionObject<IListItem> Model { get; } = new(model);
 
-    [ObservableProperty]
-    public partial ObservableCollection<TagViewModel>? Tags { get; set; }
+    public List<TagViewModel>? Tags { get; set; }
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
@@ -110,24 +107,20 @@ public partial class ListItemViewModel(IListItem model, IPageContext context)
 
     private void UpdateTags(ITag[]? newTagsFromModel)
     {
-        var newTags = newTagsFromModel?.Select(t =>
-        {
-            var vm = new TagViewModel(t, PageContext);
-            vm.InitializeProperties();
-            return vm;
-        })
-            .ToList() ?? [];
-
         Task.Factory.StartNew(
             () =>
             {
-                // The Tags ObservableCollection _MUST_ be created on the UI
-                // thread. If it isn't, then binding to it's changes in the UI won't work
-                Tags ??= new();
-                lock (Tags)
+                var newTags = newTagsFromModel?.Select(t =>
                 {
-                    ListHelpers.InPlaceUpdateList(Tags, newTags);
-                }
+                    var vm = new TagViewModel(t, PageContext);
+                    vm.InitializeProperties();
+                    return vm;
+                })
+                    .ToList() ?? [];
+
+                // Tags being an ObservableCollection instead of a List lead to
+                // many COM exception issues.
+                Tags = new(newTags);
 
                 UpdateProperty(nameof(Tags));
                 UpdateProperty(nameof(HasTags));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/Tag.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/Tag.xaml.cs
@@ -43,6 +43,10 @@ public partial class Tag : Control
         set => SetValue(TextProperty, value);
     }
 
+    private Brush? originalBg;
+    private Brush? originalFg;
+    private Brush? originalBorder;
+
     public static readonly DependencyProperty ForegroundColorProperty =
         DependencyProperty.Register(nameof(ForegroundColor), typeof(OptionalColor), typeof(Tag), new PropertyMetadata(null, OnForegroundColorPropertyChanged));
 
@@ -64,6 +68,10 @@ public partial class Tag : Control
     {
         base.OnApplyTemplate();
 
+        // Application.Current.Resources["TagBackground"] as Brush;
+        originalBg = Application.Current.Resources["TagBackground"] as Brush;
+        originalFg = Application.Current.Resources["TagForeground"] as Brush;
+        originalBorder = Application.Current.Resources["TagBorderBrush"] as Brush;
         if (GetTemplateChild(TagIconBox) is IconBox iconBox)
         {
             iconBox.SourceRequested += IconCacheProvider.SourceRequested;
@@ -73,15 +81,25 @@ public partial class Tag : Control
 
     private static void OnForegroundColorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is not Tag tag || tag.ForegroundColor is null || !tag.ForegroundColor.HasValue)
+        if (d is not Tag tag)
         {
             return;
         }
 
-        if (OptionalColorBrushCacheProvider.Convert(tag.ForegroundColor.Value) is SolidColorBrush brush)
+        if (/*tag.Foreground is null || */!tag.ForegroundColor.HasValue)
+        {
+            tag.Foreground = tag.originalFg;
+            tag.BorderBrush = tag.originalBorder;
+        }
+        else if (OptionalColorBrushCacheProvider.Convert(tag.ForegroundColor.Value) is SolidColorBrush brush)
         {
             tag.Foreground = brush;
             tag.BorderBrush = brush;
+        }
+        else
+        {
+            tag.Foreground = tag.originalFg;
+            tag.BorderBrush = tag.originalBorder;
         }
     }
 
@@ -92,9 +110,14 @@ public partial class Tag : Control
             return;
         }
 
-        if (OptionalColorBrushCacheProvider.Convert(tag.BackgroundColor.Value) is SolidColorBrush brush)
+        if (/*tag.Background is null || */!tag.BackgroundColor.HasValue)
         {
-            tag.Background = brush;
+            // foo bar
+            tag.Background = tag.originalBg;
+        }
+        else
+        {
+            tag.Background = OptionalColorBrushCacheProvider.Convert(tag.BackgroundColor.Value) is SolidColorBrush brush ? brush : tag.originalBg;
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/Tag.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/Tag.xaml.cs
@@ -84,15 +84,21 @@ public partial class Tag : Control
             return;
         }
 
-        if (!tag.ForegroundColor.HasValue)
-        {
-            tag.Foreground = OriginalFg;
-            tag.BorderBrush = OriginalBorder;
-        }
-        else if (OptionalColorBrushCacheProvider.Convert(tag.ForegroundColor.Value) is SolidColorBrush brush)
+        if (tag.ForegroundColor != null &&
+            OptionalColorBrushCacheProvider.Convert(tag.ForegroundColor.Value) is SolidColorBrush brush)
         {
             tag.Foreground = brush;
-            tag.BorderBrush = brush;
+
+            // If we have a BG color, then don't apply a border.
+            if (tag.BackgroundColor is OptionalColor bg && bg.HasValue)
+            {
+                tag.BorderBrush = OriginalBorder;
+            }
+            else
+            {
+                // Otherwise (no background), use the FG as the border
+                tag.BorderBrush = brush;
+            }
         }
         else
         {
@@ -103,13 +109,45 @@ public partial class Tag : Control
 
     private static void OnBackgroundColorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is not Tag tag || tag.BackgroundColor is null || !tag.BackgroundColor.HasValue)
+        if (d is not Tag tag)
         {
             return;
         }
 
-        tag.Background = !tag.BackgroundColor.HasValue
-            ? OriginalBg
-            : OptionalColorBrushCacheProvider.Convert(tag.BackgroundColor.Value) is SolidColorBrush brush ? brush : OriginalBg;
+        if (tag.BackgroundColor != null &&
+            OptionalColorBrushCacheProvider.Convert(tag.BackgroundColor.Value) is SolidColorBrush brush)
+        {
+            tag.Background = brush;
+
+            // Since we have a BG here, we never want a border.
+            tag.BorderBrush = OriginalBorder;
+
+            // If we have a FG color, then don't apply a border.
+            if (tag.ForegroundColor is OptionalColor fg && fg.HasValue)
+            {
+                tag.BorderBrush = OriginalBorder;
+            }
+            else
+            {
+                // Otherwise (no foreground), use the FG as the border
+                tag.BorderBrush = brush;
+            }
+        }
+        else
+        {
+            // No BG color here.
+            tag.Background = OriginalBg;
+
+            // If we have a FG color, then don't apply a border.
+            if (tag.ForegroundColor is OptionalColor fg && fg.HasValue)
+            {
+                tag.BorderBrush = tag.Foreground;
+            }
+            else
+            {
+                // Otherwise (no foreground), use the FG as the border
+                tag.BorderBrush = OriginalBorder;
+            }
+        }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/Tag.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/Tag.xaml.cs
@@ -43,9 +43,11 @@ public partial class Tag : Control
         set => SetValue(TextProperty, value);
     }
 
-    private Brush? originalBg;
-    private Brush? originalFg;
-    private Brush? originalBorder;
+    private static Brush? OriginalBg => Application.Current.Resources["TagBackground"] as Brush;
+
+    private static Brush? OriginalFg => Application.Current.Resources["TagForeground"] as Brush;
+
+    private static Brush? OriginalBorder => Application.Current.Resources["TagBorderBrush"] as Brush;
 
     public static readonly DependencyProperty ForegroundColorProperty =
         DependencyProperty.Register(nameof(ForegroundColor), typeof(OptionalColor), typeof(Tag), new PropertyMetadata(null, OnForegroundColorPropertyChanged));
@@ -68,10 +70,6 @@ public partial class Tag : Control
     {
         base.OnApplyTemplate();
 
-        // Application.Current.Resources["TagBackground"] as Brush;
-        originalBg = Application.Current.Resources["TagBackground"] as Brush;
-        originalFg = Application.Current.Resources["TagForeground"] as Brush;
-        originalBorder = Application.Current.Resources["TagBorderBrush"] as Brush;
         if (GetTemplateChild(TagIconBox) is IconBox iconBox)
         {
             iconBox.SourceRequested += IconCacheProvider.SourceRequested;
@@ -86,10 +84,10 @@ public partial class Tag : Control
             return;
         }
 
-        if (/*tag.Foreground is null || */!tag.ForegroundColor.HasValue)
+        if (!tag.ForegroundColor.HasValue)
         {
-            tag.Foreground = tag.originalFg;
-            tag.BorderBrush = tag.originalBorder;
+            tag.Foreground = OriginalFg;
+            tag.BorderBrush = OriginalBorder;
         }
         else if (OptionalColorBrushCacheProvider.Convert(tag.ForegroundColor.Value) is SolidColorBrush brush)
         {
@@ -98,8 +96,8 @@ public partial class Tag : Control
         }
         else
         {
-            tag.Foreground = tag.originalFg;
-            tag.BorderBrush = tag.originalBorder;
+            tag.Foreground = OriginalFg;
+            tag.BorderBrush = OriginalBorder;
         }
     }
 
@@ -110,14 +108,8 @@ public partial class Tag : Control
             return;
         }
 
-        if (/*tag.Background is null || */!tag.BackgroundColor.HasValue)
-        {
-            // foo bar
-            tag.Background = tag.originalBg;
-        }
-        else
-        {
-            tag.Background = OptionalColorBrushCacheProvider.Convert(tag.BackgroundColor.Value) is SolidColorBrush brush ? brush : tag.originalBg;
-        }
+        tag.Background = !tag.BackgroundColor.HasValue
+            ? OriginalBg
+            : OptionalColorBrushCacheProvider.Convert(tag.BackgroundColor.Value) is SolidColorBrush brush ? brush : OriginalBg;
     }
 }


### PR DESCRIPTION
* Issue the first: This hit with the media controls sample. I'm not really sure how it happened, with the menu changing which we were initializing it? But it happens, and now it doesn't
* Issues the second: `Tags` was an `ObservableCollection`, and that was getting created off the UI thread, then updated on the UI thread, and everyone was upset, and there was a pile of COM WRONG_THREAD issues. 
* ISSUE THE THIRD: FIXES THE TAG COLORS! Closes #365 