### PR TITLE
Add some tooltips, and tighten up some phrasing

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Shell/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Shell/Properties/Resources.Designer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CmdPal.Ext.Shell.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Shell.
+        ///   Looks up a localized string similar to Run commands.
         /// </summary>
         public static string cmd_plugin_name {
             get {

--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Shell/Properties/Resources.resx
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Shell/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="cmd_plugin_name" xml:space="preserve">
-    <value>Shell</value>
+    <value>Run commands</value>
   </data>
   <data name="cmd_plugin_description" xml:space="preserve">
     <value>Executes commands (e.g. 'ping', 'cmd')</value>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TagViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TagViewModel.cs
@@ -11,11 +11,13 @@ public partial class TagViewModel(ITag _tag, IPageContext context) : ExtensionOb
 {
     private readonly ExtensionObject<ITag> _tagModel = new(_tag);
 
+    public string ToolTip => string.IsNullOrEmpty(ModelToolTip) ? Text : ModelToolTip;
+
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
     public string Text { get; private set; } = string.Empty;
 
-    public string ToolTip { get; private set; } = string.Empty;
+    public string ModelToolTip { get; private set; } = string.Empty;
 
     public OptionalColor Foreground { get; private set; }
 
@@ -36,7 +38,7 @@ public partial class TagViewModel(ITag _tag, IPageContext context) : ExtensionOb
         Text = model.Text;
         Foreground = model.Foreground;
         Background = model.Background;
-        ToolTip = model.ToolTip;
+        ModelToolTip = model.ToolTip;
         Icon = new(model.Icon);
         Icon.InitializeProperties();
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -229,8 +229,8 @@
                 Padding="4"
                 Content="{ui:FontIcon Glyph=&#xE712;,
                                       FontSize=16}"
-                ToolTipService.ToolTip="Ctrl+k"
                 Style="{StaticResource SubtleButtonStyle}"
+                ToolTipService.ToolTip="Ctrl+k"
                 Visibility="{x:Bind ViewModel.ShouldShowContextMenu, Mode=OneWay}">
                 <Button.Flyout>
                     <Flyout Placement="TopEdgeAlignedRight">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -145,7 +145,7 @@
             FontSize="12"
             Text="{x:Bind CurrentPageViewModel.Title, Mode=OneWay}"
             Visibility="{x:Bind CurrentPageViewModel.IsNested, Mode=OneWay}" />
-        <!--  TO DO: Replace with ItemsRepeater and bind "Primary commands"?  -->
+
         <StackPanel
             Grid.Column="2"
             HorizontalAlignment="Right"
@@ -229,6 +229,7 @@
                 Padding="4"
                 Content="{ui:FontIcon Glyph=&#xE712;,
                                       FontSize=16}"
+                ToolTipService.ToolTip="Ctrl+k"
                 Style="{StaticResource SubtleButtonStyle}"
                 Visibility="{x:Bind ViewModel.ShouldShowContextMenu, Mode=OneWay}">
                 <Button.Flyout>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -47,7 +47,6 @@
         <!--  https://learn.microsoft.com/windows/apps/design/controls/itemsview#specify-the-look-of-the-items  -->
         <DataTemplate x:Key="ListItemViewModelTemplate" x:DataType="viewmodels:ListItemViewModel">
 
-            <!--  TODO: collapse item if it's empty  -->
             <Grid Padding="0,12,0,12" ColumnSpacing="12">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="28" />
@@ -160,7 +159,6 @@
                 </StackPanel>
             </controls:Case>
         </controls:SwitchPresenter>
-
 
     </Grid>
 </Page>

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Indexer/IndexerCommandsProvider.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Indexer/IndexerCommandsProvider.cs
@@ -14,7 +14,9 @@ public partial class IndexerCommandsProvider : CommandProvider
 
     public IndexerCommandsProvider()
     {
+        Id = "Files";
         DisplayName = Resources.IndexerCommandsProvider_DisplayName;
+        Icon = Icons.FileExplorerSegoe;
     }
 
     public override ICommandItem[] TopLevelCommands()

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Indexer/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Indexer/Properties/Resources.Designer.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CmdPal.Ext.Indexer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Indexer file search commands.
+        ///   Looks up a localized string similar to File search.
         /// </summary>
         internal static string IndexerCommandsProvider_DisplayName {
             get {

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Indexer/Properties/Resources.resx
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Indexer/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="IndexerCommandsProvider_DisplayName" xml:space="preserve">
-    <value>Indexer file search commands</value>
+    <value>File search</value>
   </data>
   <data name="Indexer_Command_Browse" xml:space="preserve">
     <value>Browse</value>


### PR DESCRIPTION
* Tags have their tooltip default to their text, if no `ToolTip` is explicitly set
* add a `ctrl+k` tooltip to the more commands button
* change the naming of "indexer" to be "file search" (which is what folks really care about)
* change the naming of "shell commands" to be "Run commands" (again, this is more intuitive)