### PR TITLE
Fix CommandPalette package checking at runtime

### DIFF
--- a/src/common/utils/package.h
+++ b/src/common/utils/package.h
@@ -46,7 +46,7 @@ namespace package {
             dwlConditionMask);
     }
 
-    inline std::optional<Package> GetRegisteredPackage(std::wstring packageDisplayName)
+    inline std::optional<Package> GetRegisteredPackage(std::wstring packageDisplayName, bool checkVersion)
     {
         PackageManager packageManager;
 
@@ -57,7 +57,8 @@ namespace package {
 
             if (packageFullName.contains(packageDisplayName))
             {
-                if (packageVersion.Major == VERSION_MAJOR && packageVersion.Minor == VERSION_MINOR && packageVersion.Revision == VERSION_REVISION)
+                // If checkVersion is true, verify if the package has the same version as PowerToys.
+                if ((!checkVersion) || (packageVersion.Major == VERSION_MAJOR && packageVersion.Minor == VERSION_MINOR && packageVersion.Revision == VERSION_REVISION))
                 {
                     return { package };
                 }
@@ -67,9 +68,9 @@ namespace package {
         return {};
     }
 
-    inline bool IsPackageRegistered(std::wstring packageDisplayName)
+    inline bool IsPackageRegisteredWithPowerToysVersion(std::wstring packageDisplayName)
     {
-        return GetRegisteredPackage(packageDisplayName).has_value();
+        return GetRegisteredPackage(packageDisplayName, true).has_value();
     }
 
     inline bool RegisterSparsePackage(const std::wstring& externalLocation, const std::wstring& sparsePkgPath)

--- a/src/modules/FileLocksmith/FileLocksmithExt/PowerToysModule.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithExt/PowerToysModule.cpp
@@ -83,7 +83,7 @@ public:
             std::wstring path = get_module_folderpath(globals::instance);
             std::wstring packageUri = path + L"\\FileLocksmithContextMenuPackage.msix";
 
-            if (!package::IsPackageRegistered(constants::nonlocalizable::ContextMenuPackageName))
+            if (!package::IsPackageRegisteredWithPowerToysVersion(constants::nonlocalizable::ContextMenuPackageName))
             {
                 package::RegisterSparsePackage(path, packageUri);
             }

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/new_utilities.h
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/new_utilities.h
@@ -180,7 +180,7 @@ namespace newplus::utilities
             static const auto new_dll_path = get_module_folderpath(module_instance_handle);
             auto new_package_uri = new_dll_path + L"\\" + constants::non_localizable::msix_package_name;
 
-            if (!package::IsPackageRegistered(constants::non_localizable::context_menu_package_name))
+            if (!package::IsPackageRegisteredWithPowerToysVersion(constants::non_localizable::context_menu_package_name))
             {
                 package::RegisterSparsePackage(new_dll_path, new_package_uri);
             }

--- a/src/modules/cmdpal/CmdPalModuleInterface/dllmain.cpp
+++ b/src/modules/cmdpal/CmdPalModuleInterface/dllmain.cpp
@@ -44,7 +44,7 @@ private:
 
     void LaunchApp()
     {
-        auto package = package::GetRegisteredPackage(L"Microsoft.CommandPalette");
+        auto package = package::GetRegisteredPackage(L"Microsoft.CommandPalette", false);
 
         if (package.has_value())
         {
@@ -200,7 +200,7 @@ public:
 
         try
         {
-            if (!package::GetRegisteredPackage(L"Microsoft.CommandPalette").has_value())
+            if (!package::GetRegisteredPackage(L"Microsoft.CommandPalette", false).has_value())
             {
                 Logger::info(L"CmdPal not installed. Installing...");
 

--- a/src/modules/imageresizer/dll/dllmain.cpp
+++ b/src/modules/imageresizer/dll/dllmain.cpp
@@ -107,7 +107,7 @@ public:
             std::wstring path = get_module_folderpath(g_hInst_imageResizer);
             std::wstring packageUri = path + L"\\ImageResizerContextMenuPackage.msix";
 
-            if (!package::IsPackageRegistered(ImageResizerConstants::ModulePackageDisplayName))
+            if (!package::IsPackageRegisteredWithPowerToysVersion(ImageResizerConstants::ModulePackageDisplayName))
             {
                 package::RegisterSparsePackage(path, packageUri);
             }

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -197,7 +197,7 @@ public:
             std::wstring path = get_module_folderpath(g_hInst);
             std::wstring packageUri = path + L"\\PowerRenameContextMenuPackage.msix";
 
-            if (!package::IsPackageRegistered(PowerRenameConstants::ModulePackageDisplayName))
+            if (!package::IsPackageRegisteredWithPowerToysVersion(PowerRenameConstants::ModulePackageDisplayName))
             {
                 package::RegisterSparsePackage(path, packageUri);
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After https://github.com/microsoft/PowerToys/commit/33ec4923898da54856336e2d8492bb737879ea39 , The logic for Command Palette module interface to verify if the package is installed is wrong because Command Palette's version doesn't track PowerToys version.

This PR makes the version check optional so we can have a different logic when checking the package for Command Palette.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested build from Dart and PowerToys started Command Palette correctly.
