### PR TITLE
Fix the MSI installer issue when App plugin is running.

### DIFF
--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Apps/Storage/Win32ProgramRepository.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Apps/Storage/Win32ProgramRepository.cs
@@ -101,7 +101,7 @@ internal sealed class Win32ProgramRepository : ListRepository<Programs.Win32Prog
         }
     }
 
-    private async Task DoOnAppRenamed(object sender, RenamedEventArgs e)
+    private async Task OnAppRenamedAsync(object sender, RenamedEventArgs e)
     {
         var oldPath = e.OldFullPath;
         var newPath = e.FullPath;
@@ -160,7 +160,7 @@ internal sealed class Win32ProgramRepository : ListRepository<Programs.Win32Prog
     {
         Task.Run(async () =>
         {
-            await DoOnAppRenamed(sender, e).ConfigureAwait(false);
+            await OnAppRenamedAsync(sender, e).ConfigureAwait(false);
         }).ConfigureAwait(false);
     }
 

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Apps/Storage/Win32ProgramRepository.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Apps/Storage/Win32ProgramRepository.cs
@@ -106,6 +106,12 @@ internal sealed class Win32ProgramRepository : ListRepository<Programs.Win32Prog
         var oldPath = e.OldFullPath;
         var newPath = e.FullPath;
 
+        // fix for https://github.com/microsoft/PowerToys/issues/34391
+        // the msi installer creates a shortcut, which is detected by the PT Run and ends up in calling this OnAppRenamed method
+        // the thread needs to be halted for a short time to avoid locking the new shortcut file as we read it, otherwise the lock causes
+        // in the issue scenario that a warning is popping up during the msi install process.
+        System.Threading.Thread.Sleep(1000);
+
         var extension = Path.GetExtension(newPath);
         Win32Program.ApplicationType oldAppType = Win32Program.GetAppTypeFromPath(oldPath);
         Programs.Win32Program? newApp = Win32Program.GetAppFromPath(newPath);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Our App plugin used the ShellLink.Open to retrieve the FullPath. But it would open the ink file exclusively. This may cause some problem. Especially when we try to upgrade some installed App through MSI installer, installer would throw exception and show a prompt to user.

Original discussion here. 

1. https://github.com/microsoft/PowerToys/pull/37654/files
2. https://[github.com/microsoft/PowerToys/pull/37924](https://github.com/microsoft/PowerToys/pull/37924)

Tested locally with VS.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

