### PR TITLE
Minor UX tweaks

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -140,24 +140,25 @@
                 <StackPanel
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
-                    Orientation="Vertical">
+                    Orientation="Vertical"
+                    Spacing="4">
                     <cpcontrols:IconBox
                         x:Name="IconBorder"
-                        Grid.Column="0"
-                        Width="36"
-                        Height="36"
+                        Width="56"
+                        Height="56"
                         Margin="8"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         SourceKey="{x:Bind ViewModel.EmptyContent.Icon, Mode=OneWay}"
                         SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
-
+                    <TextBlock
+                        Margin="0,4,0,0"
+                        HorizontalAlignment="Center"
+                        FontWeight="SemiBold"
+                        Text="{x:Bind ViewModel.EmptyContent.Title, Mode=OneWay}" />
                     <TextBlock
                         HorizontalAlignment="Center"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{x:Bind ViewModel.EmptyContent.Title, Mode=OneWay}" />
-                    <TextBlock HorizontalAlignment="Center" Text="{x:Bind ViewModel.EmptyContent.Subtitle, Mode=OneWay}" />
-
+                        Text="{x:Bind ViewModel.EmptyContent.Subtitle, Mode=OneWay}" />
                 </StackPanel>
             </controls:Case>
         </controls:SwitchPresenter>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -88,7 +88,9 @@
                 </StackPanel>
 
                 <ItemsView
+                    Grid.RowSpan="2"
                     Grid.Column="2"
+                    VerticalAlignment="Center"
                     IsHitTestVisible="False"
                     IsItemInvokedEnabled="False"
                     IsTabStop="False"
@@ -142,8 +144,8 @@
                     <cpcontrols:IconBox
                         x:Name="IconBorder"
                         Grid.Column="0"
-                        Width="64"
-                        Height="64"
+                        Width="36"
+                        Height="36"
                         Margin="8"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         SourceKey="{x:Bind ViewModel.EmptyContent.Icon, Mode=OneWay}"
@@ -151,8 +153,8 @@
 
                     <TextBlock
                         HorizontalAlignment="Center"
-                        FontSize="24"
-                        Style="{ThemeResource HeaderTextBlockStyle}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
                         Text="{x:Bind ViewModel.EmptyContent.Title, Mode=OneWay}" />
                     <TextBlock HorizontalAlignment="Center" Text="{x:Bind ViewModel.EmptyContent.Subtitle, Mode=OneWay}" />
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -297,13 +297,12 @@
                 <ScrollViewer
                     x:Name="DetailsContent"
                     Grid.Column="1"
-                    Padding="12"
                     HorizontalAlignment="Stretch"
                     Background="{ThemeResource LayerFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1,0,0,0"
                     Visibility="Collapsed">
-                    <Grid>
+                    <Grid Margin="12">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />


### PR DESCRIPTION
- Tweaking the empty-screen icon + text visualization
- Fixed a bug in the details pane that clipped the content when scrolling (we were using padding on the scrollviewer vs. margin on the child grid)
- Vertically center the tags on the item line